### PR TITLE
Fix regular expression on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can export all the images needed by d2-docker to a single file, ready to dis
 Note that you must commit any changes first, since this will export images, not containers.
 
 ```
-$ d2-docker export -i eyeseetea/dhis2-data:2.30-sierra dhis2-sierra.tgz
+$ d2-docker export -i eyeseetea/dhis2-data:2.30-sierra dhis2-sierra
 ```
 
 Now you can copy this file to any other machine, which may now use commands _import FILE_ and _start FILE_.

--- a/src/d2_docker/commands/export.py
+++ b/src/d2_docker/commands/export.py
@@ -20,7 +20,7 @@ def run(args):
     yaml_contents = result.stdout.decode("utf-8")
 
     # Use regexp instead of using a third-party YAML parser to ease deployment on Windows.
-    image_names = re.findall(r"image: (\S+)$", yaml_contents, re.MULTILINE)
+    image_names = re.findall(r"image: (\S+)\r?$", yaml_contents, re.MULTILINE)
     utils.logger.info("Export images: {}".format(", ".join(image_names)))
     tar_file = args.output_file + ".tar"
     utils.save_images(image_names, tar_file)


### PR DESCRIPTION
```
Note that $ matches \n but does not match \r\n (the combination of carriage return and newline characters, or CR/LF). To match the CR/LF character combination, include \r?$ in the regular expression pattern.
```