### PR TITLE
Remove trailing comma

### DIFF
--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -197,7 +197,7 @@ def run_docker_compose(
     load_from_data=True,
     post_sql_dir=None,
     scripts_dir=None,
-    **kwargs,
+    **kwargs
 ):
     """
     Run a docker-compose command for a given image.


### PR DESCRIPTION
Installation worked fine in my laptop but I was getting this error in travis:

```
$ sudo d2-docker --help
Traceback (most recent call last):
  File "/usr/local/bin/d2-docker", line 9, in <module>
    load_entry_point('d2-docker==1.0.4', 'console_scripts', 'd2-docker')()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.5/dist-packages/d2_docker-1.0.4-py3.5.egg/d2_docker/cli.py", line 5, in <module>
    from d2_docker import utils
  File "/usr/local/lib/python3.5/dist-packages/d2_docker-1.0.4-py3.5.egg/d2_docker/utils.py", line 200
    **kwargs,
            ^
SyntaxError: invalid syntax
```
