### PR TITLE
Add redirect to dashboard for nginx

### DIFF
--- a/src/d2_docker/config/nginx.conf
+++ b/src/d2_docker/config/nginx.conf
@@ -24,6 +24,8 @@ http {
     root /data/apps;
 
     client_max_body_size 100m;
+
+    rewrite ^/$ $scheme://$http_host/dhis-web-dashboard redirect;
     
     location / {
       include mime.types;


### PR DESCRIPTION
This seems to solve the error with restarting host and booting up dockers without the wait_on.

See related issue: https://github.com/dhis2/docker-compose/commit/8c7d9e175b605c35cd9644895d214b7ed57e91f5