### PR TITLE
Feature/adjust data permissions

### DIFF
--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e -u -o pipefail
 #
 # Tasks:
@@ -22,11 +22,9 @@ root_db_path="/data/db"
 post_db_path="/data/db/post"
 source_apps_path="/data/apps"
 dest_apps_path="/DHIS2_home/files/"
-warfile="/usr/local/tomcat/webapps/ROOT.war"
-tomcatdir="/usr/local/tomcat"
 
 debug() {
-    echo "[dhis2-core-start] $@" >&2
+    echo "[dhis2-core-start] $*" >&2
 }
 
 run_sql_files() {

--- a/src/d2_docker/images/dhis2-core/docker-entrypoint.sh
+++ b/src/d2_docker/images/dhis2-core/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 WARFILE=/usr/local/tomcat/webapps/ROOT.war
 TOMCATDIR=/usr/local/tomcat
 DHIS2HOME=/DHIS2_home
+DATA_DIR="/data/"
 
 if [ "$(id -u)" = "0" ]; then
     if [ -f $WARFILE ]; then
@@ -11,9 +12,11 @@ if [ "$(id -u)" = "0" ]; then
         rm $WARFILE
     fi
     
-    chown -R tomcat:tomcat $TOMCATDIR
-    chmod -R u+rwX,g+rX,o-rwx $TOMCATDIR
-    chown -R tomcat:tomcat $TOMCATDIR/temp \
+    chown -R tomcat:tomcat $DATA_DIR $TOMCATDIR
+    chmod -R u+rwX,g+rX,o-rwx $DATA_DIR $TOMCATDIR
+    chown -R tomcat:tomcat \
+    $DATA_DIR \
+    $TOMCATDIR/temp \
     $TOMCATDIR/work \
     $TOMCATDIR/logs
     


### PR DESCRIPTION
Solves problem with data that the user tomcat in core cannot access. Example logs:

```
core_1     | cp: can't stat '/data/apps/advanced-export/asset-manifest.json': Permission denied
core_1     | cp: can't stat '/data/apps/advanced-export/manifest.webapp': Permission denied
core_1     | cp: can't stat '/data/apps/advanced-export/img': Permission denied
```