### PR TITLE
Revert nginx rewrite and move containers to custom network

### DIFF
--- a/src/d2_docker/config/nginx.conf
+++ b/src/d2_docker/config/nginx.conf
@@ -25,8 +25,6 @@ http {
 
     client_max_body_size 100m;
 
-    rewrite ^/$ $scheme://$http_host/dhis-web-dashboard redirect;
-    
     location / {
       include mime.types;
       try_files $uri $uri/ $uri/index.html @core;

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -18,6 +18,9 @@ services:
         command: sh /config/dhis2-core-start.sh
         depends_on:
             - "db"
+        restart: unless-stopped
+        networks:
+            - d2-docker
     db:
         image: "mdillon/postgis:10-alpine"
         labels:
@@ -29,6 +32,9 @@ services:
             POSTGRES_USER: dhis
             POSTGRES_PASSWORD: dhis
         command: "postgres -c max_locks_per_transaction=100"
+        restart: unless-stopped
+        networks:
+            - d2-docker
     gateway:
         image: "jwilder/nginx-proxy:alpine"
         labels:
@@ -41,6 +47,9 @@ services:
             - /var/run/docker.sock:/tmp/docker.sock:ro
         depends_on:
             - "core"
+        restart: unless-stopped
+        networks:
+            - d2-docker
     data:
         image: "${DHIS2_DATA_IMAGE}"
         environment:
@@ -54,3 +63,5 @@ volumes:
     home:
     data:
     empty:
+networks:
+    d2-docker:


### PR DESCRIPTION
- Revert nginx rewrite to dashboards-app
- Add restart policy ``unless-stopped`` (this makes the dockers boot up again if the host computer restarts)
- Move all containers to the same network (does not harm and it seems to mitigate the issue in my tests although I'm not convinced it solves the root cause)