### PR TITLE
Add option start --tomcat-server-xml=SERVER.XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,36 @@ Some notes:
 -   Use option `--run-sql=DIRECTORY` to run SQL files (.sql, .sql.gz or .dump files) after the DB has been initialized.
 -   Use option `--run-scripts=DIRECTORY` to run shell scripts (.sh) from a directory within the `dhis2-core` container. By default, a script is run **after** postgres starts (`host=db`, `port=5432`) but **before** Tomcat starts; if its filename starts with prefix "post", it will be run **after** Tomcat is available. `curl` and typical shell tools are available on that Alpine Linux environment. Note that the Dhis2 endpoint is always `http://localhost:8080`, regardless of the public port that the instance is exposed to. Of course, this endpoint is only available for post-scripts.
 
+#### Custom Tomcat server.xml
+
+Copy the default [server.xml](https://github.com/EyeSeeTea/d2-docker/blob/master/src/d2_docker/config/server.xml) and use it as a template to create your own configuration. Then pass it to the `start` command:
+
+```
+$ d2-docker start --tomcat-server-xml=server-xml.xml ...
+```
+
+Note that you should not change the catalina connector port (8080, by default). A typical configuration to use _https_ would look like this:
+
+```
+<Server port="8005" shutdown="SHUTDOWN">
+    ...
+    <Service name="Catalina">
+        <Connector
+            port="8080"
+            protocol="HTTP/1.1"
+            proxyPort="443"
+            scheme="https"
+            secure="true"
+            proxyName="some-host.org"
+            connectionTimeout="20000"
+            URIEncoding="UTF-8"
+            relaxedQueryChars='\ { } | [ ]'
+            redirectPort="8443"
+        />
+    ...
+/>
+```
+
 ### Show logs for running containers
 
 Check logs of a running container:
@@ -214,11 +244,11 @@ $ d2-docker upgrade \
 
 Migration folder `upgrade-sierra` should then contain data to be used in each intermediate upgrade version. Supported migration data:
 
-- DHIS2 war file: `dhis.war` (if not specified, it will be download from the releases page)
-- DHIS2 home files: `dhis2-home/`
-- Shell scripts (pre-tomcat): `*.sh`
-- Shell scripts (post-tomcat): `post-*.sh`
-- SQL files: `*.sql`
+-   DHIS2 war file: `dhis.war` (if not specified, it will be download from the releases page)
+-   DHIS2 home files: `dhis2-home/`
+-   Shell scripts (pre-tomcat): `*.sh`
+-   Shell scripts (post-tomcat): `post-*.sh`
+-   SQL files: `*.sql`
 
 A full example might look:
 

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -1,12 +1,17 @@
 import os
 import re
 
+import d2_docker
 from d2_docker import utils
 
 DESCRIPTION = "Start a container from an existing dhis2-data Docker image or from an exported file"
 
 
 def setup(parser):
+    d2_docker_path = os.path.abspath(d2_docker.__path__[0])
+    server_xml_path = os.path.join(d2_docker_path, "config", "server.xml")
+    server_xml_help = "Use a custom Tomcat server.xml file. Template: {0}".format(server_xml_path)
+
     parser.add_argument(
         "image_or_file", metavar="IMAGE_OR_EXPORT_FILE", help="Docker image or exported file"
     )
@@ -17,7 +22,7 @@ def setup(parser):
     parser.add_argument(
         "-k", "--keep-containers", action="store_true", help="Keep existing containers"
     )
-    parser.add_argument("--tomcat-server-xml", metavar="FILE", help="Use custom Tomcat server.xml")
+    parser.add_argument("--tomcat-server-xml", metavar="FILE", help=server_xml_help)
     parser.add_argument("--run-sql", metavar="DIRECTORY", help="Run .sql[.gz] files in directory")
     parser.add_argument(
         "--run-scripts",

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -17,6 +17,7 @@ def setup(parser):
     parser.add_argument(
         "-k", "--keep-containers", action="store_true", help="Keep existing containers"
     )
+    parser.add_argument("--tomcat-server-xml", metavar="FILE", help="Use custom Tomcat server.xml")
     parser.add_argument("--run-sql", metavar="DIRECTORY", help="Run .sql[.gz] files in directory")
     parser.add_argument(
         "--run-scripts",
@@ -82,6 +83,7 @@ def start(args, image_name):
             load_from_data=override_containers,
             post_sql_dir=args.run_sql,
             scripts_dir=args.run_scripts,
+            tomcat_server=args.tomcat_server_xml
         )
 
     if args.detach:

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -23,6 +23,7 @@ root_db_path="/data/db"
 post_db_path="/data/db/post"
 source_apps_path="/data/apps"
 dest_apps_path="/DHIS2_home/files/"
+tomcat_conf_dir="/usr/local/tomcat/conf"
 
 debug() {
     echo "[dhis2-core-start] $*" >&2
@@ -73,9 +74,11 @@ copy_apps() {
 }
 
 setup_tomcat() {
+    debug "Setup tomcat"
     cp -v "$configdir/DHIS2_home/dhis.conf" /DHIS2_home/dhis.conf
     cp -v $homedir/* /DHIS2_home/ || true
-    cp -v "$configdir/server.xml" /usr/local/tomcat/conf/server.xml
+    cp -v "$configdir/server.xml" "$tomcat_conf_dir/server.xml"
+    find "$configdir/override/tomcat/" -maxdepth 1 -type f -size +0 -exec cp -v {} "$tomcat_conf_dir/" \;
 }
 
 wait_for_postgres() {

--- a/src/d2_docker/config/server.xml
+++ b/src/d2_docker/config/server.xml
@@ -18,14 +18,20 @@
     </GlobalNamingResources>
 
     <Service name="Catalina">
-        <Connector port="8080" protocol="HTTP/1.1"
-            connectionTimeout="20000"
+        <Connector
+            protocol="HTTP/1.1"
+            port="8080"
             redirectPort="8443"
+            connectionTimeout="20000"
             URIEncoding="UTF-8"
             relaxedQueryChars='\ { } | [ ]'
         />
 
-        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+        <Connector
+            protocol="AJP/1.3"
+            port="8009"
+            redirectPort="8443"
+        />
 
         <Engine name="Catalina" defaultHost="localhost">
             <Realm className="org.apache.catalina.realm.LockOutRealm">

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             - home:/DHIS2_home
             - ./config:/config
             - data:/data
+            - "${TOMCAT_SERVER}:/config/override/tomcat/server.xml"
             - "${SCRIPTS_DIR}:/data/scripts"
             - "${POST_SQL_DIR}:/data/db/post"
         environment:

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -201,6 +201,7 @@ def run_docker_compose(
     load_from_data=True,
     post_sql_dir=None,
     scripts_dir=None,
+    tomcat_server=None,
     **kwargs,
 ):
     """
@@ -224,6 +225,7 @@ def run_docker_compose(
         # Set default values for directory, required by docker-compose volumes section
         ("POST_SQL_DIR", post_sql_dir_abs),
         ("SCRIPTS_DIR", scripts_dir_abs),
+        ("TOMCAT_SERVER", get_abs_file_for_docker_volume(tomcat_server)),
     ]
     env = dict((k, v) for (k, v) in [pair for pair in env_pairs if pair] if v)
 
@@ -232,7 +234,7 @@ def run_docker_compose(
 
 
 def get_absdir_for_docker_volume(directory):
-    """Return absolute path for given directory, with default fallback."""
+    """Return absolute path for given directory, with fallback to empty directory."""
     if not directory:
         empty_directory = os.path.join(os.path.dirname(__file__), ".empty")
         return empty_directory
@@ -240,6 +242,14 @@ def get_absdir_for_docker_volume(directory):
         raise D2DockerError("Should be a directory: {}".format(directory))
     else:
         return os.path.abspath(directory)
+
+
+def get_abs_file_for_docker_volume(file_path):
+    """Return absolute path for given file, with fallback to empty file."""
+    if not file_path:
+        return os.path.join(os.path.dirname(__file__), ".empty", "placeholder")
+    else:
+        return os.path.abspath(file_path)
 
 
 def get_item_type(name):


### PR DESCRIPTION
Closes #47

```
$ d2-docker start --help
...
  --tomcat-server-xml FILE
                        Use custom Tomcat server.xml. Template: /usr/lib/python3.8/site-packages/d2_docker-1.0.7-py3.8.egg/d2_docker/config/server.xml
...
```

Example:

```
$ cp /usr/lib/python3.8/site-packages/d2_docker-1.0.7-py3.8.egg/d2_docker/config/server.xml my-custom-server.xml
$ d2-docker start eyeseetea/dhis2-data:2.32-samaritans --tomcat-server-xml=my-custom-server.xml
```