### PR TITLE
Add d2-docker start --auth=USER:PASS option used in pre/post scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Some notes:
 -   Use option `--detach` to run the container in the background.
 -   Use option `--deploy-path` to run the container with a deploy path namespace (i.e: `--deploy-path=dhis2` serves `http://localhost:8080/dhis2`)
 -   Use option `-k`/`--keep-containers` to re-use existing docker containers, so data from the previous run will be kept.
+-   Use option `-auth` to pass the instance authentication (`USER:PASS`). It will be used to call post-tomcat scripts.
 -   Use option `--run-sql=DIRECTORY` to run SQL files (.sql, .sql.gz or .dump files) after the DB has been initialized.
 -   Use option `--run-scripts=DIRECTORY` to run shell scripts (.sh) from a directory within the `dhis2-core` container. By default, a script is run **after** postgres starts (`host=db`, `port=5432`) but **before** Tomcat starts; if its filename starts with prefix "post", it will be run **after** Tomcat is available. `curl` and typical shell tools are available on that Alpine Linux environment. Note that the Dhis2 endpoint is always `http://localhost:8080/${deployPath}`, regardless of the public port that the instance is exposed to.
 

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -11,6 +11,7 @@ def setup(parser):
         "image_or_file", metavar="IMAGE_OR_EXPORT_FILE", help="Docker image or exported file"
     )
     utils.add_core_image_arg(parser)
+    parser.add_argument("--auth", metavar="USER:PASSWORD", help="Dhis2 instance authentication")
     parser.add_argument(
         "-d", "--detach", action="store_true", help="Run containers on the background"
     )
@@ -85,7 +86,8 @@ def start(args, image_name):
             load_from_data=override_containers,
             post_sql_dir=args.run_sql,
             scripts_dir=args.run_scripts,
-            deploy_path=deploy_path
+            deploy_path=deploy_path,
+            dhis2_auth=args.auth
         )
 
     if args.detach:

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -11,10 +11,12 @@ set -e -u -o pipefail
 
 # Global: LOAD_FROM_DATA="yes" | "no"
 # Global: DEPLOY_PATH=string
+# Global: DHIS2_AUTH=string
 
 export PGPASSWORD="dhis"
 
 dhis2_url="http://localhost:8080/$DEPLOY_PATH"
+dhis2_url_with_auth="http://$DHIS2_AUTH@localhost:8080/$DEPLOY_PATH"
 psql_cmd="psql -v ON_ERROR_STOP=0 --quiet -h db -U dhis dhis2"
 pgrestore_cmd="pg_restore -h db -U dhis -d dhis2"
 configdir="/config"
@@ -54,14 +56,14 @@ run_sql_files() {
 run_pre_scripts() {
     find "$scripts_dir" -type f -name '*.sh' ! \( -name 'post*' \) | sort | while read -r path; do
         debug "Run pre-tomcat script: $path"
-        (cd "$(dirname "$path")" && bash "$path")
+        (cd "$(dirname "$path")" && bash -x "$path" "$dhis2_url_with_auth")
     done
 }
 
 run_post_scripts() {
     find "$scripts_dir" -type f -name '*.sh' -name 'post*' | sort | while read -r path; do
         debug "Run post-tomcat script: $path"
-        (cd "$(dirname "$path")" && bash "$path")
+        (cd "$(dirname "$path")" && bash -x "$path" "$dhis2_url_with_auth")
     done
 }
 

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -56,7 +56,7 @@ run_sql_files() {
 run_pre_scripts() {
     find "$scripts_dir" -type f -name '*.sh' ! \( -name 'post*' \) | sort | while read -r path; do
         debug "Run pre-tomcat script: $path"
-        (cd "$(dirname "$path")" && bash -x "$path" "$dhis2_url_with_auth")
+        (cd "$(dirname "$path")" && bash -x "$path")
     done
 }
 

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -15,6 +15,7 @@ services:
             JAVA_OPTS: "-Xmx7500m -Xms4000m"
             LOAD_FROM_DATA: "${LOAD_FROM_DATA}"
             DEPLOY_PATH: "${DEPLOY_PATH}"
+            DHIS2_AUTH: "${DHIS2_AUTH}"
         entrypoint: sh /config/dhis2-core-entrypoint.sh
         command: sh /config/dhis2-core-start.sh
         depends_on:

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -202,6 +202,7 @@ def run_docker_compose(
     post_sql_dir=None,
     scripts_dir=None,
     deploy_path="",
+    dhis2_auth=None,
     **kwargs,
 ):
     """
@@ -226,6 +227,7 @@ def run_docker_compose(
         ("POST_SQL_DIR", post_sql_dir_abs),
         ("SCRIPTS_DIR", scripts_dir_abs),
         ("DEPLOY_PATH", deploy_path),
+        ("DHIS2_AUTH", dhis2_auth),
     ]
     env = dict((k, v) for (k, v) in [pair for pair in env_pairs if pair] if v)
 


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/d2-cloner/pull/7

When running post-tomcat scripts, we need pass the instance URL with auth, so add an option in d2-docker start:

```
d2-docker start --auth=admin:district --run-scripts=/path/to/scripts ...
```

And now `/path/to/scripts/post-*.sh` shell scripts will get "http://admin:district@localhost:8080" as its first argument (`$1`). Note that it's always 8080 because those scripts are run inside the tomcat container.