### PR TITLE
Support old setuptools versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 include src/d2_docker/docker-compose.yml
 recursive-include src/d2_docker/config *
 recursive-include src/d2_docker/images *
+recursive-include src/d2_docker/.empty *


### PR DESCRIPTION
The directory `.empty`, which contains an empty file and directory required as a fallback for empty mounts, it's not copied by old setuptools packages (tested with 39.0 -> not copied, 44.1 -> copied). Force explicit copy in the manifest.

@ifoche Not sure that's the problem you were facing, but it's safer to have this anyway.