### PR TITLE
Add support for documents folder (files/document)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ $ d2-docker create core eyeseetea/dhis2-core:2.30 --war=dhis.war --dhis2-home=/t
 
 ### Create a base DHIS2 data image
 
-Create a dhis2-data image from a .sql.gz SQL file and the apps directory to include:
+Create a dhis2-data image from a .sql.gz SQL file and the apps and documents directory to include:
 
 ```
-$ d2-docker create data eyeseetea/dhis2-data:2.30-sierra --sql=sierra-db.sql.gz [--apps-dir=path/to/apps]
+$ d2-docker create data eyeseetea/dhis2-data:2.30-sierra --sql=sierra-db.sql.gz [--apps-dir=path/to/apps] [--documents-dir=path/to/document]
 ```
 
 ### Start a DHIS2 instance
@@ -125,7 +125,7 @@ _If only one d2-docker container is active, you can omit the image name._
 
 ### Commit & push an image
 
-This will update the image from the current container (SQL dump and apps):
+This will update the image from the current container (SQL dump, apps and documents):
 
 ```
 $ d2-docker commit
@@ -193,7 +193,7 @@ $ d2-docker rm eyeseetea/dhis2-data:2.30-sierra
 
 ### Copy Docker images to/from local directories
 
-You can use a Docker image or a data directory (db + apps) as source, that will create a new Docker image _eyeseetea/dhis2-data:2.30-sierra2_ and a `sierra-data/` directory:
+You can use a Docker image or a data directory (db + apps + documents) as source, that will create a new Docker image _eyeseetea/dhis2-data:2.30-sierra2_ and a `sierra-data/` directory:
 
 ```
 $ d2-docker copy eyeseetea/dhis2-data:2.30-sierra eyeseetea/dhis2-data:2.30-sierra2 sierra-data
@@ -202,10 +202,10 @@ $ docker image ls | grep 2.30-sierra2
 eyeseetea/dhis2-data      2.30-sierra2         930aced0d915        1 minutes ago      106MB
 
 $ ls sierra-data/
-apps db.sql.gz
+apps document db.sql.gz
 ```
 
-Alternatively, you can use a data directory (db + apps) as source and create Docker images from it:
+Alternatively, you can use a data directory (db + apps + documents) as source and create Docker images from it:
 
 ```
 $ d2-docker copy sierra-data eyeseetea/dhis2-data:2.30-sierra3 eyeseetea/dhis2-data:2.30-sierra4

--- a/src/d2_docker/commands/copy.py
+++ b/src/d2_docker/commands/copy.py
@@ -40,3 +40,5 @@ def copy(source, destinations, docker_dir):
             utils.copytree(source, dest)
         else:
             raise utils.D2DockerError("Not implemented")
+
+        logger.info("Done")

--- a/src/d2_docker/commands/create.py
+++ b/src/d2_docker/commands/create.py
@@ -21,6 +21,7 @@ def setup(parser):
     data_parser.add_argument("data_image", metavar="IMAGE", help="Image core name")
     data_parser.add_argument("--sql", help=".sql (plain text), .sql.gz (gzipped plain text format) or .dump database file (binary format)")
     data_parser.add_argument("--apps-dir", help="Directory containing Dhis2 apps")
+    data_parser.add_argument("--documents-dir", help="Directory containing Dhis2 documents")
 
 
 def run(args):
@@ -55,6 +56,10 @@ def create_data(args):
             dest_apps_dir = os.path.join(build_dir, "apps")
             utils.logger.debug("Copy apps: {} -> {}".format(args.apps_dir, dest_apps_dir))
             utils.copytree(args.apps_dir, dest_apps_dir)
+        if args.documents_dir:
+            dest_documents_dir = os.path.join(build_dir, "document")
+            utils.logger.debug("Copy documents: {} -> {}".format(args.documents_dir, dest_documents_dir))
+            utils.copytree(args.documents_dir, dest_documents_dir)
         if args.sql:
             utils.logger.debug("Copy DB file:  {} -> {}".format(args.sql, db_path))
             shutil.copy(args.sql, db_path)

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -25,7 +25,8 @@ scripts_dir="/data/scripts"
 root_db_path="/data/db"
 post_db_path="/data/db/post"
 source_apps_path="/data/apps"
-dest_apps_path="/DHIS2_home/files/"
+source_documents_path="/data/document"
+files_path="/DHIS2_home/files/"
 tomcat_conf_dir="/usr/local/tomcat/conf"
 
 debug() {
@@ -34,6 +35,8 @@ debug() {
 
 run_sql_files() {
     base_db_path=$(test "${LOAD_FROM_DATA}" = "yes" && echo "$root_db_path" || echo "$post_db_path")
+    debug "Files in data path"
+    find "$base_db_path" >&2;
 
     find "$base_db_path" -type f \( -name '*.dump' \) |
         sort | while read -r path; do
@@ -69,10 +72,18 @@ run_post_scripts() {
 }
 
 copy_apps() {
-    debug "Copy Dhis2 apps: $source_apps_path -> $dest_apps_path"
-    mkdir -p "$dest_apps_path/apps"
+    debug "Copy Dhis2 apps: $source_apps_path -> $files_path"
+    mkdir -p "$files_path/apps"
     if test -e "$source_apps_path"; then
-        cp -Rv "$source_apps_path" "$dest_apps_path"
+        cp -Rv "$source_apps_path" "$files_path"
+    fi
+}
+
+copy_documents() {
+    debug "Copy Dhis2 documents: $source_documents_path -> $files_path"
+    mkdir -p "$files_path/document"
+    if test -e "$source_documents_path"; then
+        cp -Rv "$source_documents_path" "$files_path"
     fi
 }
 
@@ -107,6 +118,7 @@ run() {
     local host=$1 psql_port=$2
     setup_tomcat
     copy_apps
+    copy_documents
     wait_for_postgres
     run_sql_files || true
     run_pre_scripts || true

--- a/src/d2_docker/images/dhis2-data/Dockerfile
+++ b/src/d2_docker/images/dhis2-data/Dockerfile
@@ -6,5 +6,6 @@ COPY db/ /data/db/
 COPY run.sh /usr/local/bin/
 
 COPY apps/ /data/apps
+COPY document/ /data/document
 
 CMD ["sh", "/usr/local/bin/run.sh"]

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -358,8 +358,8 @@ def export_data_from_running_containers(image_name, containers, destination):
     apps_source = "{}:/DHIS2_home/files/apps/".format(containers["core"])
     run(["docker", "cp", apps_source, destination])
 
-    apps_source = "{}:/DHIS2_home/files/document/".format(containers["core"])
-    run(["docker", "cp", apps_source, destination])
+    documents_source = "{}:/DHIS2_home/files/document/".format(containers["core"])
+    run(["docker", "cp", documents_source, destination])
 
     db_path = os.path.join(destination, "db", "db.sql.gz")
     export_database(image_name, db_path)

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -63,6 +63,14 @@ def run(command_parts, raise_on_error=True, env=None, capture_output=False, **kw
         raise D2DockerError(msg.format(cmd, exc.returncode, exc.stderr))
 
 
+@contextlib.contextmanager
+def possible_errors():
+    try:
+        yield
+    except D2DockerError as exc:
+        pass
+
+
 def get_free_port(start=8080, end=65535):
     for port in range(start, end):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -315,7 +323,7 @@ def copy_image(docker_dir, source_image, dest_image):
 
 
 def build_image_from_directory(docker_dir, data_dir, dest_image_name):
-    """Build docker image from data (db + apps) directory."""
+    """Build docker image from data (db + apps + documents) directory."""
     with tempfile.TemporaryDirectory() as temp_dir_root:
         logger.info("Create temporal directory: {}".format(temp_dir_root))
         temp_dir = os.path.join(temp_dir_root, "contents")
@@ -329,21 +337,28 @@ def build_image_from_directory(docker_dir, data_dir, dest_image_name):
 
 
 def export_data_from_image(source_image, dest_path):
+    logger.info("Export data from image: {} -> {}".format(source_image, dest_path))
     result = run(["docker", "create", source_image], capture_output=True)
     container_id = result.stdout.decode("utf8").splitlines()[0]
     mkdir_p(dest_path)
     try:
         run(["docker", "cp", container_id + ":" + "/data/db", dest_path])
-        run(["docker", "cp", container_id + ":" + "/data/apps", dest_path])
+        with possible_errors():
+            run(["docker", "cp", container_id + ":" + "/data/apps", dest_path])
+            run(["docker", "cp", container_id + ":" + "/data/document", dest_path])
     finally:
         run(["docker", "rm", "-v", container_id])
 
 
 def export_data_from_running_containers(image_name, containers, destination):
-    """Export data (db + apps) from a running Docker container to a destination directory."""
+    """Export data (db + apps + documents) from a running Docker container to a destination directory."""
     logger.info("Copy Dhis2 apps")
-    apps_source = "{}:/DHIS2_home/files/apps/".format(containers["core"])
     mkdir_p(destination)
+
+    apps_source = "{}:/DHIS2_home/files/apps/".format(containers["core"])
+    run(["docker", "cp", apps_source, destination])
+
+    apps_source = "{}:/DHIS2_home/files/document/".format(containers["core"])
     run(["docker", "cp", apps_source, destination])
 
     db_path = os.path.join(destination, "db", "db.sql.gz")


### PR DESCRIPTION
Closes https://app.clickup.com/t/kk8gbv

## Notes

Commands involved:

- create data: new option to add documents.
- start: copy documents from the image to the container.
- commit: copy document from the container to the image.
- copy: copy documents image->filesystem and filesystem->image.

## Notes for the tester

Install:

```bash
$ sudo python setup.py install
```

I'll be using a Samaritans image, you can use any other image you are familiar with. First, let's test that images without documents work with the new code:

```bash
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans

# Test copy (it will show a warning about <document> folder not existing):
$ d2-docker copy eyeseetea/dhis2-data:2.32.6-samaritans sp1
$ find sp1

# Test that we can create an image back
$ d2-docker copy sp1 eyeseetea/dhis2-data:2.32.6-samaritans2

$ d2-docker commit eyeseetea/dhis2-data:2.32.6-samaritans
```

Now let's test with documents. Go to App "Reports (beta)" and upload a file. And then

```bash
$ d2-docker commit eyeseetea/dhis2-data:2.32.6-samaritans

$ d2-docker copy eyeseetea/dhis2-data:2.32.6-samaritans sp2
$ find sp2 | grep document

$ d2-docker stop eyeseetea/dhis2-data:2.32.6-samaritans

$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans
# Check that the document exist
```

Test `d2-docker create data` with documents:

```bash
$ d2-docker create data --sql=sp2/db/db.sql.gz --documents-dir=sp2/document eyeseetea/dhis2-data:2.32.6-samaritans2
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans2 -p 8081
# Check that the document exist
```