### PR TITLE
Add option to start command to override JAVA_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Some notes:
 -   Use option `-auth` to pass the instance authentication (`USER:PASS`). It will be used to call post-tomcat scripts.
 -   Use option `--run-sql=DIRECTORY` to run SQL files (.sql, .sql.gz or .dump files) after the DB has been initialized.
 -   Use option `--run-scripts=DIRECTORY` to run shell scripts (.sh) from a directory within the `dhis2-core` container. By default, a script is run **after** postgres starts (`host=db`, `port=5432`) but **before** Tomcat starts; if its filename starts with prefix "post", it will be run **after** Tomcat is available. `curl` and typical shell tools are available on that Alpine Linux environment. Note that the Dhis2 endpoint is always `http://localhost:8080/${deployPath}`, regardless of the public port that the instance is exposed to.
--   Use option `--java-opts="JAVA_OPTS"` to override the default java_opts for the Tomcat process. That's tipically use to set the maximum/minimum memory, for example `--java-opts="-Xmx3500m -Xms2500m"`
+-   Use option `--java-opts="JAVA_OPTS"` to override the default JAVA_OPTS for the Tomcat process. That's tipically used to set the maximum/initial Heap Memory size (for example: `--java-opts="-Xmx3500m -Xms2500m"`)
 
 #### Custom Tomcat server.xml
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Some notes:
 -   Use option `-auth` to pass the instance authentication (`USER:PASS`). It will be used to call post-tomcat scripts.
 -   Use option `--run-sql=DIRECTORY` to run SQL files (.sql, .sql.gz or .dump files) after the DB has been initialized.
 -   Use option `--run-scripts=DIRECTORY` to run shell scripts (.sh) from a directory within the `dhis2-core` container. By default, a script is run **after** postgres starts (`host=db`, `port=5432`) but **before** Tomcat starts; if its filename starts with prefix "post", it will be run **after** Tomcat is available. `curl` and typical shell tools are available on that Alpine Linux environment. Note that the Dhis2 endpoint is always `http://localhost:8080/${deployPath}`, regardless of the public port that the instance is exposed to.
+-   Use option `--java-opts="JAVA_OPTS"` to override the default java_opts for the Tomcat process. That's tipically use to set the maximum/minimum memory, for example `--java-opts="-Xmx3500m -Xms2500m"`
 
 #### Custom Tomcat server.xml
 

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -33,6 +33,7 @@ def setup(parser):
     parser.add_argument("--pull", action="store_true", help="Force a pull from docker hub")
     parser.add_argument("-p", "--port", type=int, metavar="N", help="Set Dhis2 instance port")
     parser.add_argument("--deploy-path", type=str, help="Set Tomcat context.path")
+    parser.add_argument("--java-opts", type=str, help="Set Tomcat JAVA_OPTS")
 
 
 def run(args):
@@ -81,7 +82,7 @@ def start(args, image_name):
         bool, ["--force-recreate" if override_containers else None, "-d" if args.detach else None]
     )
 
-    deploy_path = ("/" + re.sub("^/*", "", args.deploy_path) if args.deploy_path else "")
+    deploy_path = "/" + re.sub("^/*", "", args.deploy_path) if args.deploy_path else ""
 
     with utils.stop_docker_on_interrupt(image_name, core_image):
         utils.run_docker_compose(
@@ -94,7 +95,8 @@ def start(args, image_name):
             scripts_dir=args.run_scripts,
             deploy_path=deploy_path,
             dhis2_auth=args.auth,
-            tomcat_server=args.tomcat_server_xml
+            tomcat_server=args.tomcat_server_xml,
+            java_opts=args.java_opts,
         )
 
     if args.detach:

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - "${POST_SQL_DIR}:/data/db/post"
         environment:
             CATALINA_OPTS: "-Dcontext.path=${DEPLOY_PATH}"
-            JAVA_OPTS: "-Xmx7500m -Xms4000m"
+            JAVA_OPTS: "-Xmx7500m -Xms4000m ${JAVA_OPTS}"
             LOAD_FROM_DATA: "${LOAD_FROM_DATA}"
             DEPLOY_PATH: "${DEPLOY_PATH}"
             DHIS2_AUTH: "${DHIS2_AUTH}"

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -202,6 +202,7 @@ def run_docker_compose(
     post_sql_dir=None,
     scripts_dir=None,
     deploy_path=None,
+    java_opts=None,
     dhis2_auth=None,
     tomcat_server=None,
     **kwargs,
@@ -228,6 +229,7 @@ def run_docker_compose(
         ("POST_SQL_DIR", post_sql_dir_abs),
         ("SCRIPTS_DIR", scripts_dir_abs),
         ("DEPLOY_PATH", deploy_path or ""),
+        ("JAVA_OPTS", java_opts or ""),
         ("DHIS2_AUTH", dhis2_auth or ""),
         ("TOMCAT_SERVER", get_abs_file_for_docker_volume(tomcat_server)),
     ]


### PR DESCRIPTION
Closes https://app.clickup.com/t/kt7nbn

## Implementation

- Using now `JAVA_OPTS: "-Xmx7500m -Xms4000m ${JAVA_OPTS}"` in `docker-compose.yml`. We've checked that duplicated options use the last value, so we can also override these default values. By the way, that's a good moment to change these defaults, if someone has a proposal.

## Notes for the tester

Install:

```bash
$ sudo python setup.py install
```

Let's make sure we've not broken anything and the old start command works fine:

```bash
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans
# Go to About Dhis2 -> Memory info, Mem Total in JVM: 4982 Free in JVM: 3638 Max Limit: 6667
```

Now let's test the new option, with a smaller Heap Space:

```bash
$ d2-docker stop eyeseetea/dhis2-data:2.32.6-samaritans
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans --java-opts="-Xmx3500m -Xms2500m"
# Go to About Dhis2 -> Memory info, Mem Total in JVM: 2686 Free in JVM: 2382 Max Limit: 3111`
```