### PR TITLE
Override dhis conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Some notes:
 -   Use option `--run-scripts=DIRECTORY` to run shell scripts (.sh) from a directory within the `dhis2-core` container. By default, a script is run **after** postgres starts (`host=db`, `port=5432`) but **before** Tomcat starts; if its filename starts with prefix "post", it will be run **after** Tomcat is available. `curl` and typical shell tools are available on that Alpine Linux environment. Note that the Dhis2 endpoint is always `http://localhost:8080/${deployPath}`, regardless of the public port that the instance is exposed to.
 -   Use option `--java-opts="JAVA_OPTS"` to override the default JAVA_OPTS for the Tomcat process. That's tipically used to set the maximum/initial Heap Memory size (for example: `--java-opts="-Xmx3500m -Xms2500m"`)
 
+#### Custom DHIS2 dhis.conf
+
+Copy the default [dhis.conf](https://github.com/EyeSeeTea/d2-docker/blob/master/src/d2_docker/config/DHIS2_home/dhis.conf) and use it as a template to create your own configuration. Then pass it to the `start` command:
+
+```
+$ d2-docker start --dhis-conf=dhis.conf ...
+```
+
 #### Custom Tomcat server.xml
 
 Copy the default [server.xml](https://github.com/EyeSeeTea/d2-docker/blob/master/src/d2_docker/config/server.xml) and use it as a template to create your own configuration. Then pass it to the `start` command:

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -81,7 +81,7 @@ def start(args, image_name):
         bool, ["--force-recreate" if override_containers else None, "-d" if args.detach else None]
     )
 
-    deploy_path = ("/" + re.sub("^/*", "", args.deploy_path) if args.deploy_path else "")
+    deploy_path = "/" + re.sub("^/*", "", args.deploy_path) if args.deploy_path else ""
 
     with utils.stop_docker_on_interrupt(image_name, core_image):
         utils.run_docker_compose(

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -9,8 +9,10 @@ DESCRIPTION = "Start a container from an existing dhis2-data Docker image or fro
 
 def setup(parser):
     d2_docker_path = os.path.abspath(d2_docker.__path__[0])
-    server_xml_path = os.path.join(d2_docker_path, "config", "server.xml")
+    server_xml_path = utils.get_config_file("server.xml")
     server_xml_help = "Use a custom Tomcat server.xml file. Template: {0}".format(server_xml_path)
+    dhis_conf_path = utils.get_config_file("DHIS2_home/dhis.conf")
+    dhis_conf_help = "Use a custom dhis.conf file. Template: {0}".format(dhis_conf_path)
 
     parser.add_argument(
         "image_or_file", metavar="IMAGE_OR_EXPORT_FILE", help="Docker image or exported file"
@@ -24,6 +26,7 @@ def setup(parser):
         "-k", "--keep-containers", action="store_true", help="Keep existing containers"
     )
     parser.add_argument("--tomcat-server-xml", metavar="FILE", help=server_xml_help)
+    parser.add_argument("--dhis-conf", metavar="FILE", help=dhis_conf_help)
     parser.add_argument("--run-sql", metavar="DIRECTORY", help="Run .sql[.gz] files in directory")
     parser.add_argument(
         "--run-scripts",
@@ -94,7 +97,8 @@ def start(args, image_name):
             scripts_dir=args.run_scripts,
             deploy_path=deploy_path,
             dhis2_auth=args.auth,
-            tomcat_server=args.tomcat_server_xml
+            tomcat_server=args.tomcat_server_xml,
+            dhis_conf=args.dhis_conf,
         )
 
     if args.detach:

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
             - "com.eyeseetea.image-name=${DHIS2_DATA_IMAGE}"
         volumes:
             - home:/DHIS2_home
+            - ${DHIS_CONF}:/config/DHIS2_home/dhis.conf
             - ./config:/config
             - data:/data
             - "${TOMCAT_SERVER}:/config/override/tomcat/server.xml"

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -212,6 +212,7 @@ def run_docker_compose(
     scripts_dir=None,
     deploy_path=None,
     dhis_conf=None,
+    java_opts=None,
     dhis2_auth=None,
     tomcat_server=None,
     **kwargs,

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -452,7 +452,12 @@ def wait_for_server(port):
 
 
 def create_core(
-    *, docker_dir, image, version=None, war=None, dhis2_home_paths=None,
+    *,
+    docker_dir,
+    image,
+    version=None,
+    war=None,
+    dhis2_home_paths=None,
 ):
     logger.info("Create core image: {}".format(image))
 


### PR DESCRIPTION
Closes https://app.clickup.com/t/kt7ntm

## Implementation

- Add a bind mount: `- ${DHIS_CONF}:/config/DHIS2_home/dhis.conf`

## Notes for the tester

Install:

```bash
$ sudo python setup.py install
```

Let's make sure we've not broken anything and the old start command works fine:

```bash
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans
```

Now execute `./d2-docker start -h` and get the default path of `dhis.conf` to create a custom one: `
cp [DEFAULT_PATH] my-dhis.conf`. Modify this file and start the container again:

```bash
$ d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans --dhis-conf my-dhis.conf
```

Make sure the instance is using this modified file (in my case, I just broke the DB password so the instance wouldn't start).