### PR TITLE
fix dhis.conf order

### DIFF
--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -89,8 +89,8 @@ copy_documents() {
 
 setup_tomcat() {
     debug "Setup tomcat"
-    cp -v "$configdir/DHIS2_home/dhis.conf" /DHIS2_home/dhis.conf
     cp -v $homedir/* /DHIS2_home/ || true
+    cp -v "$configdir/DHIS2_home/dhis.conf" /DHIS2_home/dhis.conf
     cp -v "$configdir/server.xml" "$tomcat_conf_dir/server.xml"
     find "$configdir/override/tomcat/" -maxdepth 1 -type f -size +0 -exec cp -v {} "$tomcat_conf_dir/" \;
 }

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -36,7 +36,7 @@ debug() {
 run_sql_files() {
     base_db_path=$(test "${LOAD_FROM_DATA}" = "yes" && echo "$root_db_path" || echo "$post_db_path")
     debug "Files in data path"
-    find "$base_db_path" >&2;
+    find "$base_db_path" >&2
 
     find "$base_db_path" -type f \( -name '*.dump' \) |
         sort | while read -r path; do
@@ -87,12 +87,20 @@ copy_documents() {
     fi
 }
 
+copy_non_empty_files() {
+    local from=$1 to=$2
+    find "$from" -maxdepth 1 -type f -size +0 -exec cp -v {} "$to" \;
+}
+
 setup_tomcat() {
     debug "Setup tomcat"
+
+    cp -v $configdir/DHIS2_home/* "/DHIS2_home/"
     cp -v $homedir/* /DHIS2_home/ || true
-    cp -v "$configdir/DHIS2_home/dhis.conf" /DHIS2_home/dhis.conf
+    copy_non_empty_files "$configdir/override/dhis2/" "/DHIS2_home/"
+
     cp -v "$configdir/server.xml" "$tomcat_conf_dir/server.xml"
-    find "$configdir/override/tomcat/" -maxdepth 1 -type f -size +0 -exec cp -v {} "$tomcat_conf_dir/" \;
+    copy_non_empty_files "$configdir/override/tomcat/" "$tomcat_conf_dir/"
 }
 
 wait_for_postgres() {

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 set -e -u -o pipefail
 #
 # Tasks:

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             - "com.eyeseetea.image-name=${DHIS2_DATA_IMAGE}"
         volumes:
             - home:/DHIS2_home
-            - ${DHIS_CONF}:/config/DHIS2_home/dhis.conf
+            - ${DHIS_CONF}:/config/override/dhis2/dhis.conf
             - ./config:/config
             - data:/data
             - "${TOMCAT_SERVER}:/config/override/tomcat/server.xml"

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -242,7 +242,7 @@ def run_docker_compose(
         ("JAVA_OPTS", java_opts or ""),
         ("DHIS2_AUTH", dhis2_auth or ""),
         ("TOMCAT_SERVER", get_absfile_for_docker_volume(tomcat_server)),
-        ("DHIS_CONF", get_config_path("DHIS2_home/dhis.conf", dhis_conf)),
+        ("DHIS_CONF", get_absfile_for_docker_volume(dhis_conf)),
     ]
     env = dict((k, v) for (k, v) in [pair for pair in env_pairs if pair] if v is not None)
 


### PR DESCRIPTION
This PR fixes the training problem with the dhis.conf file.
That file was overriden by the core file in each start.
I can see in the training log:

^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.252936054Z '/config/DHIS2_home/dhis.conf' -> '/DHIS2_home/dhis.conf'
^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.261476805Z '/dhis2-home-files/dhis.conf' -> '/DHIS2_home/dhis.conf'
^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.263120267Z '/config/server.xml' -> '/usr/local/tomcat/conf/server.xml'
^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.267238237Z [dhis2-core-start] Copy Dhis2 apps: /data/apps -> /DHIS2_home/files/
^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.267263732Z '/config/override/tomcat/server.xml' -> '/usr/local/tomcat/conf/server.xml'
^[[33mcore_1     |^[[0m 2021-07-31T22:05:54.269223321Z '/data/apps/.placeholder' -> '/DHIS2_home/files/apps/.placeholder'


Where /dhis2-home-files/dhis.conf  its the core dhis.conf, and /config/DHIS2_home/dhis.conf' the dhis.conf provided by param.

I test all situations in local:
start with -k, without -k, with --dhis-conf=/tmp/dhis.conf and without them.
I suggest to test it in trainning the next monday.