### PR TITLE
Install basic fonts (required by api/charts)

### DIFF
--- a/src/d2_docker/images/dhis2-core/Dockerfile
+++ b/src/d2_docker/images/dhis2-core/Dockerfile
@@ -12,11 +12,10 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
     addgroup root tomcat && \
     adduser -S -D -G tomcat tomcat
 
-RUN apk add --update --no-cache bash su-exec curl postgresql-client
+RUN apk add --update --no-cache bash su-exec curl postgresql-client fontconfig ttf-dejavu
 
 COPY dhis.war /usr/local/tomcat/webapps/ROOT.war
 COPY dhis2-home-files /dhis2-home-files
-
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 


### PR DESCRIPTION
A report from Samaritans IP pointed out that the history chart in data-entry->datavalue->audit was not being rendered:

![image](https://user-images.githubusercontent.com/24643/154688204-546597e0-2dbd-4967-9a5d-cd2783ae58aa.png)

That chart URL is http://localhost:8080/api/charts/history/data.png, which returns a 500, with the following traceback in the server:

```
core_1     | 2022-02-18T09:38:37.631276627Z java.lang.NullPointerException
core_1     | 2022-02-18T09:38:37.632608004Z     at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
core_1     | 2022-02-18T09:38:37.632679780Z     at sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:219)
core_1     | 2022-02-18T09:38:37.632882193Z     at sun.awt.FontConfiguration.init(FontConfiguration.java:107)
```

This error occurs because the distro in the docker, Alpine, is very basic and does not provide any font. The solution is simply to install `fontconfig` and `ttf-dejavu`.

Note that I've not added the static *apk* files to `src/d2_docker/config/apk`, `ttf-dejavu` is quite big, I'd prefer not to add it to the repo. As the problem is not critical, I think re-creating the core image when needed is enough.

Tested and working in SP-IP servers.

Testing: Create a core and check that the audit graph is rendered.