### PR TITLE
Add option start --bind-ip=IP

### DIFF
--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -34,6 +34,7 @@ def setup(parser):
     )
     parser.add_argument("--pull", action="store_true", help="Force a pull from docker hub")
     parser.add_argument("-p", "--port", type=int, metavar="N", help="Set Dhis2 instance port")
+    parser.add_argument("--bind-ip", type=str, metavar="IP", help="Bind Dhis2 instance to IP")
     parser.add_argument("--deploy-path", type=str, help="Set Tomcat context.path")
     parser.add_argument("--java-opts", type=str, help="Set Tomcat JAVA_OPTS")
     parser.add_argument("--postgis-version", type=str, help="Set PostGIS database version")
@@ -92,6 +93,7 @@ def start(args, image_name):
             ["up", *up_args],
             image_name,
             port=port,
+            bind_ip=args.bind_ip,
             core_image=core_image,
             load_from_data=override_containers,
             post_sql_dir=args.run_sql,

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -43,7 +43,7 @@ services:
             - "com.eyeseetea.image-name=${DHIS2_DATA_IMAGE}"
             - "com.eyeseetea.deploy-path=${DEPLOY_PATH}"
         ports:
-            - "${DHIS2_CORE_PORT:-8080}:80"
+            - "${DHIS2_CORE_IP:-}${DHIS2_CORE_PORT:-8080}:80"
         volumes:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/50x.html:/usr/share/nginx/html/50x.html:ro

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -188,8 +188,8 @@ def get_image_status(image_name):
 
 
 def get_port_from_docker_ports(info):
-    port_re = r"0\.0\.0\.0:(\d+)->80"
-    match = re.match(port_re, info)
+    port_re = r":(\d+)->80/tcp"
+    match = re.search(port_re, info)
     port = int(match.group(1)) if match else None
     return port
 

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -225,6 +225,7 @@ def run_docker_compose(
     load_from_data=True,
     post_sql_dir=None,
     db_port=None,
+    bind_ip=None,
     scripts_dir=None,
     deploy_path=None,
     dhis_conf=None,
@@ -250,6 +251,7 @@ def run_docker_compose(
     env_pairs = [
         ("DHIS2_DATA_IMAGE", final_image_name),
         ("DHIS2_CORE_PORT", str(port)) if port else None,
+        ("DHIS2_CORE_IP", bind_ip + ":") if bind_ip else "",
         ("DHIS2_CORE_IMAGE", core_image_name),
         ("LOAD_FROM_DATA", "yes" if load_from_data else "no"),
         # Set default values for directory, required by docker-compose volumes section


### PR DESCRIPTION
Required by:

https://app.clickup.com/t/1z4m02x
https://github.com/EyeSeeTea/project-monitoring-app/pull/433

## Testing

Check that this works and 8080 is listening only for localhost:

```
$ d2-docker start DATA_IMAGE -p 8080 --bind-ip=127.0.0.1
$ sudo lsof -i :8080 
```

If no options `--bind-ip` is specified, it should be working as usual.

```
$ d2-docker start DATA_IMAGE -p 8080
$ sudo lsof -i :8080 
```