### PR TITLE
added missing java fonts to draw visualizations as images

### DIFF
--- a/src/d2_docker/images/dhis2-core/Dockerfile
+++ b/src/d2_docker/images/dhis2-core/Dockerfile
@@ -13,7 +13,7 @@ RUN rm -rf /usr/local/tomcat/webapps/* && \
     adduser -S -D -G tomcat tomcat
 
 RUN apk add --update --no-cache bash su-exec curl postgresql-client
-
+RUN apk add --no-cache ttf-dejavu
 COPY dhis.war /usr/local/tomcat/webapps/ROOT.war
 COPY dhis2-home-files /dhis2-home-files
 


### PR DESCRIPTION
This package fixes a error drawing the visualizations as images:

java.lang.ExceptionInInitializerError
	org.apache.batik.bridge.UserAgentAdapter.getFontFamilyResolver(UserAgentAdapter.java:465)
	org.apache.batik.bridge.BridgeContext.getFontFamilyResolver(BridgeContext.java:284)
	org.apache.batik.bridge.SVGTextElementBridge.getFontList(SVGTextElementBridge.java:1518)
