### PR TITLE
Add option to push also core, disabled by default

### DIFF
--- a/src/d2_docker/commands/push.py
+++ b/src/d2_docker/commands/push.py
@@ -5,6 +5,9 @@ DESCRIPTION = "Push dhis2-data docker image"
 
 def setup(parser):
     parser.add_argument(
+        "--with-core", action="store_true", help="Push also dhis2-core companion image"
+    )
+    parser.add_argument(
         "image", metavar="IMAGE", type=str, nargs="?", help="Docker dhis2-data image"
     )
 
@@ -14,6 +17,7 @@ def run(args):
     utils.logger.info("Push data image: {}".format(data_image_name))
     utils.push_image(data_image_name)
 
-    core_image_name = utils.get_core_image_name(data_image_name)
-    utils.logger.info("Push core image: {}".format(core_image_name))
-    utils.push_image(core_image_name)
+    if args.with_core:
+        core_image_name = utils.get_core_image_name(data_image_name)
+        utils.logger.info("Push core image: {}".format(core_image_name))
+        utils.push_image(core_image_name)


### PR DESCRIPTION
We made a change for `d2-docker push` to push both data and core images, but usually the remote core should not be updated. This PR adds an explicit option `--with-core` to push it, so now only the data image is pushed by default.