### PR TITLE
Add support for newer version of Docker allowing dashes for container names

### DIFF
--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -174,9 +174,12 @@ def get_image_status(image_name):
         if len(parts) != 3:
             continue
         image_name_part, container_name, ports = parts
-        indexed_service = container_name.split("_", 2)[-2:]
-        if image_name_part == final_image_name and indexed_service:
-            service = indexed_service[0]
+        # Depending on the docker version, the container name may be stringfromimage_service-1 OR
+        # stringfromimage_service_1. Split by all posible character separators.
+        parts = re.split(r"[-_]", container_name)
+        service = parts[-2] if len(parts) >= 2 else None
+
+        if image_name_part == final_image_name and service:
             containers[service] = container_name
             if service == "gateway":
                 port = get_port_from_docker_ports(ports)


### PR DESCRIPTION
On newer versions of docker/docker-compose (20.10.17 / 2.0.1) we get: 

```
$ sudo d2-docker commit
[d2-docker:INFO] Container must be running to build image
```

That's because now dashes (`-`) are allowed in a container name when previously they were transformed to underscores (`_`). This commit makes it work with both separators.