### PR TITLE
Set shm_size to 1gb (default 64m)

### DIFF
--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
             - "db"
     db:
         image: "postgis/postgis:${POSTGIS_VERSION:-14-3.2-alpine}"
+        shm_size: 1gb
         labels:
             - "com.eyeseetea.image-name=${DHIS2_DATA_IMAGE}"
         volumes:


### PR DESCRIPTION
Motivation: We had on sp-cpr-dev errors of the type: "* ERROR 2022-09-16T18:05:17,624 Analytics table process failed: java.lang.RuntimeException: Exception during execution"

Solution: Expand shard memory for the db/postgres container.