### PR TITLE
[logs] add --limit and use a default for follow mode

### DIFF
--- a/src/d2_docker/commands/logs.py
+++ b/src/d2_docker/commands/logs.py
@@ -7,12 +7,21 @@ def setup(parser):
     parser.add_argument("image", metavar="IMAGE", nargs="?", help="Hub docker image")
     parser.add_argument("-f", "--follow", action="store_true", help="Follow log output")
     parser.add_argument("-s", "--service", help="Container service")
+    parser.add_argument("-n", "--limit", help="Limit number of lines to show", type=int)
 
 
 def run(args):
     image_name = args.image or utils.get_running_image_name()
     utils.logger.info("Show logs: {}".format(image_name))
-    args = ["logs", "-t", "-f" if args.follow else None, args.service]
+    tail_count = args.limit or (10 if args.follow else None)
+
+    args = [
+        "logs",
+        "--timestamps",
+        "--tail={}".format(tail_count) if tail_count else None,
+        "--follow" if args.follow else None,
+        args.service,
+    ]
     utils.run_docker_compose(filter(bool, args), image_name)
 
 


### PR DESCRIPTION
Required by https://app.clickup.com/t/3megcwe

Two changes in command logs that should be useful:

- Add the typical `-n/--limit` to limit the output count
- When using `--follow` mode, docker returns by default the complete log. That's unwieldy; typically, UNIX tools return a small fixed amount of the last lines and then follow. I've set that default to 10. 