### PR TITLE
[run-sql] Add --dump option to dump the current DB without commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ Run a SQL file or open an interactive postgres session in a running Dhis2 instan
 $ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
 ```
 
+### Dump current database to SQL file in container
+
+```
+$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
+```
+
 ### Upgrade DHIS2 version
 
 ```

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ eyeseetea/dhis2-data 2.30-sierra4 d3a374301234 1 minutes ago 106MB
 Lists _dhis2-data_ images present in the local repository and the container status:
 
 ```
-$ d2-docker.py list
+$ d2-docker list
 eyeseetea/dhis2-data:2.30-sierra RUNNING[port=8080]
 eyeseetea/dhis2-data:2.30-vietnam STOPPED
 eyeseetea/dhis2-data:2.30-cambodia STOPPED
@@ -243,13 +243,13 @@ eyeseetea/dhis2-data:2.30-cambodia STOPPED
 Run a SQL file or open an interactive postgres session in a running Dhis2 instance:
 
 ```
-$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
+$ d2-docker run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
 ```
 
 ### Dump current database to SQL file in container
 
 ```
-$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
+$ d2-docker run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
 ```
 
 ### Upgrade DHIS2 version

--- a/src/d2_docker/commands/run_sql.py
+++ b/src/d2_docker/commands/run_sql.py
@@ -12,6 +12,7 @@ def setup(parser):
         nargs="?",
         help="SQL file (if empty, open interactive psql terminal)",
     )
+    parser.add_argument("--dump", action="store_true", help="Dump SQL")
 
 
 def run(args):
@@ -25,13 +26,20 @@ def run(args):
     with running_containers(image_name, "db") as status:
         db_container = status["containers"]["db"]
         utils.logger.debug("DB container: {}".format(db_container))
-        psql_cmd = ["psql", "-U", "dhis", "dhis2"]
-        cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
-        if sql_file:
-            utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
-        stdin = open(sql_file, encoding="utf-8") if sql_file else None
-        result = utils.run(cmd, stdin=stdin, raise_on_error=False)
 
-        if result.returncode != 0:
-            utils.logger.error("Could not execute SQL")
-            return 1
+        if args.dump:
+            cmd = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2"]
+            utils.logger.info("Dump SQL for image {}".format(image_name))
+            utils.run(cmd, raise_on_error=False)
+        else:
+            if sql_file:
+                utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
+
+            psql_cmd = ["psql", "-U", "dhis", "dhis2"]
+            cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
+            stdin = open(sql_file, encoding="utf-8") if sql_file else None
+            result = utils.run(cmd, stdin=stdin, raise_on_error=False)
+
+            if result.returncode != 0:
+                utils.logger.error("Could not execute SQL")
+                return 1


### PR DESCRIPTION
Required by https://app.clickup.com/t/3megcwe

- A very typical use case, dump the current DB without need to commit: `d2-docker run-sql --dump` 