### PR TITLE
Increase NGINX timeout to 5mins

### DIFF
--- a/src/d2_docker/config/nginx.conf
+++ b/src/d2_docker/config/nginx.conf
@@ -21,10 +21,14 @@ http {
     listen 80;
     port_in_redirect off;
 
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
+
     root /data/apps;
 
     client_max_body_size 100m;
-    
+
     location / {
       include mime.types;
       try_files $uri $uri/ $uri/index.html @core;


### PR DESCRIPTION
Required by https://app.clickup.com/t/3megcwe

Set nginx timeouts to 300 -> 5 minutes