### PR TITLE
Feature/api logs db dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ Run a SQL file or open an interactive postgres session in a running Dhis2 instan
 $ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
 ```
 
+### Dump current database to SQL file in container
+
+```
+$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
+```
+
 ### Upgrade DHIS2 version
 
 ```

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ eyeseetea/dhis2-data 2.30-sierra4 d3a374301234 1 minutes ago 106MB
 Lists _dhis2-data_ images present in the local repository and the container status:
 
 ```
-$ d2-docker.py list
+$ d2-docker list
 eyeseetea/dhis2-data:2.30-sierra RUNNING[port=8080]
 eyeseetea/dhis2-data:2.30-vietnam STOPPED
 eyeseetea/dhis2-data:2.30-cambodia STOPPED
@@ -243,13 +243,13 @@ eyeseetea/dhis2-data:2.30-cambodia STOPPED
 Run a SQL file or open an interactive postgres session in a running Dhis2 instance:
 
 ```
-$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
+$ d2-docker run-sql [-i eyeseetea/dhis2-data:2.30-sierra] some-query.sql
 ```
 
 ### Dump current database to SQL file in container
 
 ```
-$ d2-docker.py run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
+$ d2-docker run-sql [-i eyeseetea/dhis2-data:2.30-sierra] --dump
 ```
 
 ### Upgrade DHIS2 version

--- a/src/d2_docker/api/api_utils.py
+++ b/src/d2_docker/api/api_utils.py
@@ -1,7 +1,8 @@
 import os
 import base64
+from datetime import datetime
 from d2_docker.commands import list_
-from flask import jsonify
+from flask import jsonify, Response
 from dotenv import dotenv_values
 
 
@@ -19,8 +20,11 @@ class Struct(object):
 
 def get_args_from_request(request):
     body = request.get_json()
-    args = Struct(body)
-    return args
+    return Struct(body)
+
+
+def get_args_from_query_strings(request):
+    return Struct(request.args.to_dict())
 
 
 def get_auth_headers(user, password):
@@ -40,6 +44,16 @@ def success():
 def server_error(message, status=500):
     body = jsonify(dict(status="ERROR", error=message))
     return (body, status)
+
+
+def stream_response(iterator, mimetype, filename):
+    response = Response(iterator, mimetype=mimetype)
+    response.headers["Content-Disposition"] = "attachment; filename={}".format(filename)
+    return response
+
+
+def get_timestamp():
+    return datetime.today().replace(microsecond=0).isoformat()
 
 
 def get_from_dotenv(name, directories):

--- a/src/d2_docker/commands/logs.py
+++ b/src/d2_docker/commands/logs.py
@@ -25,10 +25,13 @@ def run(args):
     utils.run_docker_compose(filter(bool, args), image_name)
 
 
-def get_logs(args):
+def get_stream_logs(args):
     image_name = args.image
     tail_count = args.limit or 10_000
-    res = utils.run_docker_compose(
-        ["logs", "--tail={}".format(tail_count)], data_image=image_name, capture_output=True
+    popen = utils.run_docker_compose(
+        ["logs", "--tail={}".format(tail_count)],
+        data_image=image_name,
+        capture_output=True,
+        return_popen=True,
     )
-    return res.stdout.decode("utf-8")
+    return utils.stream_from_popen(popen)

--- a/src/d2_docker/commands/run_sql.py
+++ b/src/d2_docker/commands/run_sql.py
@@ -12,6 +12,7 @@ def setup(parser):
         nargs="?",
         help="SQL file (if empty, open interactive psql terminal)",
     )
+    parser.add_argument("--dump", action="store_true", help="Dump SQL")
 
 
 def run(args):
@@ -25,13 +26,20 @@ def run(args):
     with running_containers(image_name, "db") as status:
         db_container = status["containers"]["db"]
         utils.logger.debug("DB container: {}".format(db_container))
-        psql_cmd = ["psql", "-U", "dhis", "dhis2"]
-        cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
-        if sql_file:
-            utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
-        stdin = open(sql_file, encoding="utf-8") if sql_file else None
-        result = utils.run(cmd, stdin=stdin, raise_on_error=False)
 
-        if result.returncode != 0:
-            utils.logger.error("Could not execute SQL")
-            return 1
+        if args.dump:
+            cmd = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2"]
+            utils.logger.info("Dump SQL for image {}".format(image_name))
+            utils.run(cmd, raise_on_error=False)
+        else:
+            if sql_file:
+                utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
+
+            psql_cmd = ["psql", "-U", "dhis", "dhis2"]
+            cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
+            stdin = open(sql_file, encoding="utf-8") if sql_file else None
+            result = utils.run(cmd, stdin=stdin, raise_on_error=False)
+
+            if result.returncode != 0:
+                utils.logger.error("Could not execute SQL")
+                return 1

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -59,7 +59,16 @@ def copytree(source, dest):
     dir_util.copy_tree(source, dest)
 
 
-def run(command_parts, raise_on_error=True, env=None, capture_output=False, **kwargs):
+def run(
+    command_parts,
+    raise_on_error=True,
+    env=None,
+    capture_output=False,
+    return_popen=False,
+    universal_newlines=True,
+    shell=False,
+    **kwargs,
+):
     """Run command and return the result subprocess object."""
     cmd = subprocess.list2cmdline(command_parts)
     if capture_output:  # Option not available for python <= 3.6, emulate
@@ -73,7 +82,12 @@ def run(command_parts, raise_on_error=True, env=None, capture_output=False, **kw
     try:
         logger.debug("Run: {}".format(cmd))
         env2 = dict(os.environ, **(env or {}))
-        return subprocess.run(command_parts, check=raise_on_error, env=env2, **kwargs)
+        if return_popen:
+            kwargs["universal_newlines"] = universal_newlines
+            popen_cmd = cmd if shell else command_parts
+            return subprocess.Popen(popen_cmd, env=env2, shell=shell, **kwargs)  # nosec
+        else:
+            return subprocess.run(command_parts, check=raise_on_error, env=env2, **kwargs)
     except subprocess.CalledProcessError as exc:
         msg = "Command {} failed with code {}: {}"
         raise D2DockerError(msg.format(cmd, exc.returncode, exc.stderr))
@@ -497,7 +511,7 @@ def wait_for_server(port):
     while True:
         try:
             logger.debug("wait_for_server:url={}".format(url))
-            urllib.request.urlopen(url)
+            urllib.request.urlopen(url)  # nosec
             logger.debug("wait_for_server:ok")
             return True
         except urllib.request.HTTPError as exc:
@@ -529,7 +543,7 @@ def create_core(
         elif version:
             war_url = get_dhis2_war(version)
             logger.info("Download file: {}".format(war_url))
-            urllib.request.urlretrieve(war_url, war_path)
+            urllib.request.urlretrieve(war_url, war_path)  # nosec
         else:
             raise D2DockerError("One option is required: --version | --war")
 
@@ -558,6 +572,32 @@ def dict_remove(d, key):
 
 def dict_merge(d1, d2):
     return {**d1, **d2}
+
+
+def stream_from_popen(popen):
+    for stdout_line in iter(popen.stdout.readline, ""):
+        yield stdout_line
+    popen.stdout.close()
+    popen.stderr.close()
+    return_code = popen.wait()
+
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, "command")
+
+
+def stream_binary_from_popen(popen):
+    while True:
+        data = popen.stdout.read(100_000)
+        if not data:
+            break
+        yield data
+
+    popen.stdout.close()
+    popen.stderr.close()
+    return_code = popen.wait()
+
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, "command")
 
 
 logger = get_logger()


### PR DESCRIPTION
Required by https://app.clickup.com/t/3megcwe

Adds two new endpoints to the API: db and logs. These endpoints do not return a JSON, they directly return the sql.gz or log files in a stream. Examples:

- `curl "http://localhost:5000/instances/db?image=docker.eyeseetea.com/samaritans_efh/dhis2-data:2.36.11-test_offline_arnau" > db.sql.gz`
- 
- curl "http://localhost:5000/instances/logs?image=docker.eyeseetea.com/samaritans_efh/dhis2-data:2.36.11-test_offline_arnau&limit=100"