### PR TITLE
[compatibility] Force amd64 platform when building images

### DIFF
--- a/src/d2_docker/commands/create.py
+++ b/src/d2_docker/commands/create.py
@@ -20,7 +20,7 @@ def setup(parser):
     data_parser.add_argument("--sql", help="Supported sql / sql.gz / dump formats")
     data_parser.add_argument("--apps-dir", help="Directory containing Dhis2 apps")
     data_parser.add_argument("--documents-dir", help="Directory containing Dhis2 documents")
-    data_parser.add_argument("--datavalues-dir", help="Directory containing Dhis2 datavalues(file resources)")
+    data_parser.add_argument("--datavalues-dir", help="Directory containing Dhis2 data values")
 
 
 def run(args):
@@ -71,4 +71,4 @@ def create_data(args):
             utils.logger.debug("Copy DB file:  {} -> {}".format(args.sql, db_path))
             shutil.copy(args.sql, db_path)
 
-        utils.run(["docker", "build", build_dir, "--tag", image])
+        utils.docker_build(build_dir, image)

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -36,6 +36,10 @@ def get_dhis2_war(version):
     return releases_base_url + "/" + path
 
 
+def docker_build(directory, tag):
+    return run(["docker", "build", "--platform", "linux/amd64", "--tag", tag, directory])
+
+
 def get_logger():
     logger_ = logging.getLogger("root")
     formatter = logging.Formatter("[d2-docker:%(levelname)s] %(message)s")
@@ -360,7 +364,7 @@ def build_image_from_source(docker_dir, source_image, dest_image):
         logger.info("Copy base docker files: {}".format(docker_dir))
         copytree(docker_dir, temp_dir)
         export_data_from_running_containers(source_image, status["containers"], temp_dir)
-        run(["docker", "build", temp_dir, "--tag", dest_image])
+        docker_build(temp_dir, dest_image)
 
 
 def copy_image(docker_dir, source_image, dest_image):
@@ -372,7 +376,7 @@ def copy_image(docker_dir, source_image, dest_image):
         logger.info("Copy base docker files: {}".format(docker_dir))
         copytree(docker_dir, temp_dir)
         export_data_from_image(source_image, temp_dir)
-        run(["docker", "build", temp_dir, "--tag", dest_image])
+        docker_build(temp_dir, dest_image)
 
 
 def build_image_from_directory(docker_dir, data_dir, dest_image_name):
@@ -386,7 +390,7 @@ def build_image_from_directory(docker_dir, data_dir, dest_image_name):
 
         logger.info("Copy data: {} -> {}".format(data_dir, temp_dir))
         copytree(data_dir, temp_dir)
-        run(["docker", "build", temp_dir, "--tag", dest_image_name])
+        docker_build(temp_dir, dest_image_name)
 
 
 def export_data_from_image(source_image, dest_path):
@@ -555,7 +559,7 @@ def create_core(
             logger.debug("Copy home file: {} -> {}".format(source_home_file, dhis2_home_path))
             shutil.copy(source_home_file, dhis2_home_path)
 
-        run(["docker", "build", build_dir, "--tag", image])
+        docker_build(build_dir, image)
 
 
 def get_config_file(filename):


### PR DESCRIPTION
The docker images pushed by Daler (using a Mac M1)  have arch arm64:

```
docker image inspect NAME | jq -r '.[].Architecture'
arm64
```

This arch does not work for Linux/Windows. We need to force amd64 architecture, which does work for Mac/Linux/Windows.