### PR TITLE
[fix] Use specific Werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.3
 python-dotenv
 Flask_Cors==3.0.10
+Werkzeug==2.3.7


### PR DESCRIPTION
We must pin the Werkzeug to 2.x as the latest version (3.x) does not work with the other dependencies.

See https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr 

Thanks, @Ramon-Jimenez 