### PR TITLE
[fix] [d2-docker commit] Make sure commit fails if pg_dump fails

### DIFF
--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -433,7 +433,7 @@ def export_database(image_name, db_path):
     mkdir_p(os.path.dirname(db_path))
 
     with open(db_path, "wb") as db_file:
-        pg_dump = "pg_dump -U dhis dhis2 | gzip"
+        pg_dump = "set -o pipefail; pg_dump -U dhis dhis2 | gzip"
         # -T: Disable pseudo-tty allocation. Otherwise the compressed output pipe is corrupted.
         cmd = ["exec", "-T", "db", "bash", "-c", pg_dump]
         run_docker_compose(cmd, image_name, stdout=db_file)


### PR DESCRIPTION
Issue: ??? (consult with Adrian)

Scenario: `d2-docker commit IMAGE` sometimes generates empty databases. 

Reason: Sometimes (very infrequently), pg_dump fails (a real example: `pg_dump: error: query failed: ERROR:  could not open relation with OID 76698183`) but d2-docker commit continues as if nothing happened. That's because the process involves a "pg_dump | gzip" pipe, and bash, by default, does not exit with an error if an intermediate command in a pipe fails.

Solution: Enable flag "pipefail" before executing the pipe.