### PR TITLE
Disable postgres JIT

### DIFF
--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
             POSTGRES_DB: dhis2
             POSTGRES_USER: dhis
             POSTGRES_PASSWORD: dhis
-        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192"
+        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192 -c jit=off"
         restart: unless-stopped
         ports:
             - "${DB_PORT}"


### PR DESCRIPTION
The official DHIS2 installation guide recommends to turn off postgres JIT: "This is important to set for postgresql versions 12 and greater. The jit compiler functionality causes a significant slowdown on many DHIS2 specific queries, eg Program Indicator queries. For versions 11 and below, the setting is off by default."

https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-master/installation.html#install_postgresql_performance_tuning

Indeed, we detected such problems with OCG databases.