### PR TITLE
Enable postgres logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ sudo python3 setup.py install
 ```
 
 If you are behind a proxy you must execute the following line to make proxy running installing pip packages:
+
 ```
 sudo -E python3 setup.py install
 ```
@@ -334,6 +335,15 @@ Create a dockerized d2-docker:
 
 ```
 $ bash build-docker-container.sh
+```
+
+## Debug SQL queries
+
+By default, d2-docker logs all SQL queries executed (one file per weekday). Example:
+
+```
+$ db_container="d2-docker-docker-eyeseetea-com-samaritans-40-4-0-sp-cpr-test-db-1"
+$ docker exec -it "$db_container" tail -f /var/lib/postgresql/data/log/queries-Thu.log
 ```
 
 ### API Server

--- a/src/d2_docker/commands/start.py
+++ b/src/d2_docker/commands/start.py
@@ -38,6 +38,8 @@ def setup(parser):
     parser.add_argument("--deploy-path", type=str, help="Set Tomcat context.path")
     parser.add_argument("--java-opts", type=str, help="Set Tomcat JAVA_OPTS")
     parser.add_argument("--postgis-version", type=str, help="Set PostGIS database version")
+    parser.add_argument("--enable-postgres-queries-logging", action="store_true",
+                        help="Enable Postgres queries logging")
 
 
 def run(args):
@@ -108,6 +110,7 @@ def start(args):
             dhis_conf=args.dhis_conf,
             java_opts=args.java_opts,
             postgis_version=args.postgis_version,
+            enable_postgres_queries_logging=args.enable_postgres_queries_logging,
         )
 
     if args.detach:

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
             POSTGRES_DB: dhis2
             POSTGRES_USER: dhis
             POSTGRES_PASSWORD: dhis
-        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192 -c jit=off -c logging_collector=on -c log_statement=all -c log_filename=queries-%a.log"
+        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192 -c jit=off ${PSQL_ENABLE_QUERY_LOGS--c logging_collector=on -c log_statement=all -c log_filename=queries-%a.log}"
         restart: unless-stopped
         ports:
             - "${DB_PORT}"

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
             POSTGRES_DB: dhis2
             POSTGRES_USER: dhis
             POSTGRES_PASSWORD: dhis
-        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192"
+        command: "postgres -c max_locks_per_transaction=100 -c max_connections=250 -c shared_buffers=3200MB -c work_mem=24MB -c maintenance_work_mem=1024MB -c effective_cache_size=8000MB -c checkpoint_completion_target=0.8 -c synchronous_commit=off -c wal_writer_delay=10000ms -c random_page_cost=1.1 -c max_locks_per_transaction=100 -c temp_buffers=16MB -c track_activity_query_size=8192 -c logging_collector=on -c log_statement=all -c log_filename=queries-%a.log"
         restart: unless-stopped
         ports:
             - "${DB_PORT}"

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -255,6 +255,7 @@ def run_docker_compose(
     dhis2_auth=None,
     tomcat_server=None,
     postgis_version=None,
+    enable_postgres_queries_logging=False,
     **kwargs,
 ):
     """
@@ -288,6 +289,7 @@ def run_docker_compose(
         ("DB_PORT", ("{}:5432".format(db_port) if db_port else "0:1000")),
         # Add ROOT_PATH from environment (required when run inside a docker)
         ("ROOT_PATH", ROOT_PATH or "."),
+        ("PSQL_ENABLE_QUERY_LOGS", "") if not enable_postgres_queries_logging else None,
     ]
     env = dict((k, v) for (k, v) in [pair for pair in env_pairs if pair] if v is not None)
 


### PR DESCRIPTION
Whenever we need to debug SQL queries, we need to enable them manually, which is unwieldy (and not all users will now how to do). This PR provide an automatic mechanism. For now, the approach is very simple, we add some options and the user interacts with the docker container.

- [x] Add option (by default, no logging is done)