### PR TITLE
[fix] Wait data container finished before core

### DIFF
--- a/src/d2_docker/config/dhis2-core-entrypoint.sh
+++ b/src/d2_docker/config/dhis2-core-entrypoint.sh
@@ -13,11 +13,43 @@ TOMCATDIR=/usr/local/tomcat
 DHIS2HOME=/DHIS2_home
 DATA_DIR=/data
 
+debug() {
+    echo "[dhis2-core-entrypoint] $*" >&2
+}
+
+curl_status_connection_refused=7
+
+wait_for_data_container_to_finish_copy() {
+    # We must wait for the data container before starting Tomcat. As ping is not installed
+    # in the image, use curl instead.
+    local statuscode
+
+    while true; do
+        statuscode=0
+        curl -sS --connect-timeout 1 data || statuscode=$?
+
+        case $statuscode in
+        "$curl_status_connection_refused")
+            debug "data container is still running, wait"
+            sleep 2
+            continue
+            ;;
+        *)
+            debug "data container has finished, continue"
+            break
+            ;;
+        esac
+    done
+
+}
+
 if [ "$(id -u)" = "0" ]; then
     if [ -f $WARFILE ]; then
         unzip -q $WARFILE -d $TOMCATDIR/webapps/ROOT
         rm -v $WARFILE # just to save space
     fi
+
+    wait_for_data_container_to_finish_copy
 
     mkdir -p $DATA_DIR/apps
     chown -R tomcat:tomcat $TOMCATDIR $DATA_DIR $DHIS2HOME

--- a/src/d2_docker/config/dhis2-core-entrypoint.sh
+++ b/src/d2_docker/config/dhis2-core-entrypoint.sh
@@ -52,8 +52,8 @@ if [ "$(id -u)" = "0" ]; then
     wait_for_data_container_to_finish_copy
 
     mkdir -p $DATA_DIR/apps
-    chown -R tomcat:tomcat $TOMCATDIR $DATA_DIR $DHIS2HOME
-    chmod -R u=rwX,g=rX,o-rwx $TOMCATDIR $DATA_DIR $DHIS2HOME
+    chown -R tomcat:tomcat $TOMCATDIR $DATA_DIR/apps $DHIS2HOME
+    chmod -R u=rwX,g=rX,o-rwx $TOMCATDIR $DATA_DIR/apps $DHIS2HOME
 
     # Launch the given command as tomcat, in two ways for backwards compatibility:
     if [ "$(grep '^ID=' /etc/os-release)" = "ID=alpine" ]; then

--- a/src/d2_docker/config/dhis2-core-entrypoint.sh
+++ b/src/d2_docker/config/dhis2-core-entrypoint.sh
@@ -6,7 +6,7 @@
 # We need our custom entrypoint to perform the following different tasks:
 #  - Make files in TOMCATDIR be of user tomcat (so we can change tomcat files in pre/post scripts)
 #
-set -e  # exit on errors
+set -e # exit on errors
 
 WARFILE=/usr/local/tomcat/webapps/ROOT.war
 TOMCATDIR=/usr/local/tomcat
@@ -16,12 +16,12 @@ DATA_DIR=/data
 if [ "$(id -u)" = "0" ]; then
     if [ -f $WARFILE ]; then
         unzip -q $WARFILE -d $TOMCATDIR/webapps/ROOT
-        rm -v $WARFILE  # just to save space
+        rm -v $WARFILE # just to save space
     fi
 
     mkdir -p $DATA_DIR/apps
-    chown -R tomcat:tomcat $TOMCATDIR $DATA_DIR/apps $DHIS2HOME
-    chmod -R u=rwX,g=rX,o-rwx $TOMCATDIR $DATA_DIR/apps $DHIS2HOME
+    chown -R tomcat:tomcat $TOMCATDIR $DATA_DIR $DHIS2HOME
+    chmod -R u=rwX,g=rX,o-rwx $TOMCATDIR $DATA_DIR $DHIS2HOME
 
     # Launch the given command as tomcat, in two ways for backwards compatibility:
     if [ "$(grep '^ID=' /etc/os-release)" = "ID=alpine" ]; then

--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         restart: unless-stopped
         depends_on:
             - "db"
+            - "data"
     db:
         image: "postgis/postgis:${POSTGIS_VERSION:-14-3.2-alpine}"
         shm_size: 1gb

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -21,8 +21,9 @@ DOCKER_COMPOSE_SERVICES = ["gateway", "core", "db"]
 ROOT_PATH = os.environ.get("ROOT_PATH")
 
 
-def get_dhis2_war(version):
-    match = re.match(r"^(\d+.\d+)", version)
+def get_dhis2_war_url(version):
+    match = (re.match(r"^(\d+.\d+)", version) if version.startswith("2.")
+        else re.match(r"^(\d+)", version))
     if not match:
         raise D2DockerError("Invalid version: {}".format(version))
     short_version = match[1]
@@ -546,7 +547,7 @@ def create_core(
             logger.debug("Copy WAR file: {} -> {}".format(war, war_path))
             shutil.copy(war, war_path)
         elif version:
-            war_url = get_dhis2_war(version)
+            war_url = get_dhis2_war_url(version)
             logger.info("Download file: {}".format(war_url))
             urllib.request.urlretrieve(war_url, war_path)  # nosec
         else:


### PR DESCRIPTION
Required by https://app.clickup.com/t/1mufv53

We've had a sync/race-condition problem all along: The "core" and "data" containers run in parallel, which typically is not a problem, as the copy is very fast, but in IP instances we had a problem, as we have a lot of data values (since folder "dataValues/" is copied before "db" folder, we ended up with an empty DB)

- [x] Wait data container to finish before core container starts the init process