### PR TITLE
Feature: Add custom tempfile base directory argument

### DIFF
--- a/src/d2_docker/cli.py
+++ b/src/d2_docker/cli.py
@@ -54,15 +54,15 @@ def get_parser():
         help="Directory containing dhis2-data docker source code",
     )
     parser.add_argument(
+        "--temp-directory",
+        metavar="DIRECTORY",
+        help="Directory to store temporary files",
+    )
+    parser.add_argument(
         "--log-level",
         metavar="NOTSET | DEBUG | INFO | WARNING | ERROR | CRITICAL",
         default="INFO",
         help="Run command with the given log level",
-    )
-    parser.add_argument(
-        "--temp-directory",
-        metavar="DIRECTORY",
-        help="Directory to store temporary files",
     )
     subparsers = parser.add_subparsers(help="Subcommands", dest="command")
 

--- a/src/d2_docker/cli.py
+++ b/src/d2_docker/cli.py
@@ -59,6 +59,11 @@ def get_parser():
         default="INFO",
         help="Run command with the given log level",
     )
+    parser.add_argument(
+        "--temp-directory",
+        metavar="DIRECTORY",
+        help="Directory to store temporary files",
+    )
     subparsers = parser.add_subparsers(help="Subcommands", dest="command")
 
     for command_module in COMMAND_MODULES:

--- a/src/d2_docker/commands/commit.py
+++ b/src/d2_docker/commands/commit.py
@@ -15,5 +15,6 @@ def setup(parser):
 def run(args):
     image_name = args.image or utils.get_running_image_name()
     docker_dir = utils.get_docker_directory("data", args)
+    temp_dir = utils.get_temp_base_directory(args)
     utils.logger.info("Commit image: {}".format(image_name))
-    utils.build_image_from_source(docker_dir, image_name, image_name)
+    utils.build_image_from_source(docker_dir, image_name, image_name, temp_dir)

--- a/src/d2_docker/commands/copy.py
+++ b/src/d2_docker/commands/copy.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from d2_docker import utils
 
 DESCRIPTION = "Copy databases from/to docker containers"
@@ -21,7 +23,7 @@ def run(args):
     copy(source, args.destinations, docker_dir, temp_dir)
 
 
-def copy(source, destinations, docker_dir, temp_dir: str | None = None):
+def copy(source, destinations, docker_dir, temp_dir: Optional[str] = None):
     logger = utils.logger
     source_type = utils.get_item_type(source)
     logger.debug("Source {} has type: {}".format(source, source_type))

--- a/src/d2_docker/commands/copy.py
+++ b/src/d2_docker/commands/copy.py
@@ -17,10 +17,11 @@ def setup(parser):
 def run(args):
     source = args.source
     docker_dir = utils.get_docker_directory("data", args)
-    copy(source, args.destinations, docker_dir)
+    temp_dir = utils.get_temp_base_directory(args)
+    copy(source, args.destinations, docker_dir, temp_dir)
 
 
-def copy(source, destinations, docker_dir):
+def copy(source, destinations, docker_dir, temp_dir=""):
     logger = utils.logger
     source_type = utils.get_item_type(source)
     logger.debug("Source {} has type: {}".format(source, source_type))
@@ -31,11 +32,11 @@ def copy(source, destinations, docker_dir):
         logger.info("Copying: {}:{} -> {}:{}".format(source_type, source, dest_type, dest))
 
         if source_type == "docker-image" and dest_type == "docker-image":
-            utils.copy_image(docker_dir, source, dest)
+            utils.copy_image(docker_dir, source, dest, temp_dir)
         elif source_type == "docker-image" and dest_type == "folder":
             utils.export_data_from_image(source, dest)
         elif source_type == "folder" and dest_type == "docker-image":
-            utils.build_image_from_directory(docker_dir, source, dest)
+            utils.build_image_from_directory(docker_dir, source, dest, temp_dir)
         elif source_type == "folder" and dest_type == "folder":
             utils.copytree(source, dest)
         else:

--- a/src/d2_docker/commands/copy.py
+++ b/src/d2_docker/commands/copy.py
@@ -21,7 +21,7 @@ def run(args):
     copy(source, args.destinations, docker_dir, temp_dir)
 
 
-def copy(source, destinations, docker_dir, temp_dir=""):
+def copy(source, destinations, docker_dir, temp_dir: str | None = None):
     logger = utils.logger
     source_type = utils.get_item_type(source)
     logger.debug("Source {} has type: {}".format(source, source_type))

--- a/src/d2_docker/commands/create.py
+++ b/src/d2_docker/commands/create.py
@@ -69,9 +69,10 @@ def get_major_version(s):
 def create_data(args):
     image = args.data_image
     docker_dir = utils.get_docker_directory("data", args)
+    temp_dir = utils.get_temp_base_directory(args)
     utils.logger.info("Create data image: {}".format(image))
 
-    with utils.temporal_build_directory(docker_dir) as build_dir:
+    with utils.temporal_build_directory(docker_dir, temp_dir) as build_dir:
         db_path = os.path.join(build_dir, "db/")
         utils.mkdir_p(db_path)
         if args.apps_dir:

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -10,6 +10,7 @@ import time
 import urllib.request
 from distutils import dir_util
 from pathlib import Path
+from typing import Optional
 
 import d2_docker
 from .image_name import ImageName
@@ -362,7 +363,7 @@ def get_temp_base_directory(args):
         temp_base_dir (str | None): --temp-directory value or None.
     """
 
-    temp_base_dir: str | None
+    temp_base_dir: Optional[str] = None
     if args and args.temp_directory:
         temp_base_dir = str(args.temp_directory)
 
@@ -370,13 +371,11 @@ def get_temp_base_directory(args):
             raise D2DockerError(f"Temporal base directory not found: {temp_base_dir}")
 
         logger.debug("Temporal directories base: %s", temp_base_dir)
-    else:
-        temp_base_dir = None
 
     return temp_base_dir
 
 
-def build_image_from_source(docker_dir, source_image, dest_image, temp_dir: str | None = None):
+def build_image_from_source(docker_dir, source_image, dest_image, temp_dir: Optional[str] = None):
     """Build a docker image from source local directory."""
     status = get_image_status(source_image)
     if status["state"] != "running":
@@ -392,7 +391,7 @@ def build_image_from_source(docker_dir, source_image, dest_image, temp_dir: str 
         docker_build(temp_dir, dest_image)
 
 
-def copy_image(docker_dir, source_image, dest_image, temp_dir: str | None = None):
+def copy_image(docker_dir, source_image, dest_image, temp_dir: Optional[str] = None):
     """Build a docker image using another one as template."""
     with tempfile.TemporaryDirectory(dir=temp_dir) as temp_dir_root:
         logger.info("Create temporal directory: {}".format(temp_dir_root))
@@ -404,7 +403,7 @@ def copy_image(docker_dir, source_image, dest_image, temp_dir: str | None = None
         docker_build(temp_dir, dest_image)
 
 
-def build_image_from_directory(docker_dir, data_dir, dest_image_name, temp_dir: str | None = None):
+def build_image_from_directory(docker_dir, data_dir, dest_image_name, temp_dir: Optional[str] = None):
     """Build docker image from data (db + apps + documents) directory."""
     with tempfile.TemporaryDirectory(dir=temp_dir) as temp_dir_root:
         logger.info("Create temporal directory: {}".format(temp_dir_root))
@@ -528,7 +527,7 @@ def stop_docker_on_interrupt(data_image, core_image):
 
 
 @contextlib.contextmanager
-def temporal_build_directory(source_dir, temp_dir: str | None = None):
+def temporal_build_directory(source_dir, temp_dir: Optional[str] = None):
     with tempfile.TemporaryDirectory(dir=temp_dir) as build_dir:
         logger.debug("Temporal directory: {}".format(build_dir))
         copytree(source_dir, build_dir)

--- a/test/init.sh
+++ b/test/init.sh
@@ -5,5 +5,6 @@ wget -nc "https://releases.dhis2.org/2.30/dhis.war"
 wget -nc "https://github.com/dhis2/dhis2-demo-db/raw/master/sierra-leone/2.30/dhis2-db-sierra-leone.sql.gz"
 
 mkdir -p upgrade-migrations/2.31
+mkdir -p custom-temp-base
 
 (cd upgrade-migrations/2.31 && wget -nc https://releases.dhis2.org/2.31/2.31.8/dhis.war)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -38,7 +38,7 @@ d2-docker commit tokland/dhis2-data:2.30-sierra
 d2-docker export image.tgz
 
 d2-docker stop tokland/dhis2-data:2.30-sierra
-d2-docker copy tokland/dhis2-data:2.30-sierra data-sierra tokland/dhis2-data:2.30-sierra2
+d2-docker --temp-directory='./custom-temp-base' copy tokland/dhis2-data:2.30-sierra data-sierra tokland/dhis2-data:2.30-sierra2
 d2-docker import image.tgz
 d2-docker start -d --run-sql=sql image.tgz
 wait_for_dhis2


### PR DESCRIPTION
### References

-   **Issue:** [Add a new option to d2-docker to define where the temporal folder is created (so we can use something different from tmp)](https://app.clickup.com/t/8695r5z6k)

### Description

This PR add a new global argument: `--temp-directory` which will be passed as the base directory to `tempfile.TemporaryDirectory` calls.

If no value is provided it passes `None`, meaning the function uses the system temp directory.