### PR TITLE
Remove nginx proxy_cookie_path security

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Docker compose >= 1.17
 - RAM memory: At least 4Gb for instance, preferrably 8Gb.
 
-On Ubuntu 18.04:
+On Ubuntu 22.04:
 
 ```
 $ sudo apt install docker.io docker-compose python3 python3-setuptools

--- a/src/d2_docker/config/nginx.conf
+++ b/src/d2_docker/config/nginx.conf
@@ -40,7 +40,6 @@ http {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
       proxy_pass http://core;
     }
 


### PR DESCRIPTION
- [x] Remove `proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";`

This override made it impossible to use non-localhost for http (and with no feedback at all, just the login page reloads). Let's just use the security headers that DHIS2 applies.

