### PR TITLE
exclude analytic tables from copy

### DIFF
--- a/src/d2_docker/commands/run_sql.py
+++ b/src/d2_docker/commands/run_sql.py
@@ -36,6 +36,7 @@ def run(args):
         else:
             if sql_file:
                 utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
+
             psql_cmd = ["psql", "-U", "dhis", "dhis2"]
             cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
             stdin = open(sql_file, encoding="utf-8") if sql_file else None

--- a/src/d2_docker/commands/run_sql.py
+++ b/src/d2_docker/commands/run_sql.py
@@ -29,7 +29,7 @@ def run(args):
         utils.logger.debug("DB container: {}".format(db_container))
 
         if args.dump:
-            cmd = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2"]
+            cmd = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2", "--exclude-table", "'analytics*'"]
             utils.logger.info("Dump SQL for image {}".format(image_name))
             utils.run(cmd, raise_on_error=False)
         else:
@@ -54,7 +54,7 @@ def get_stream_db(image):
         raise utils.D2DockerError("Container must be running to dump database")
 
     db_container = status["containers"]["db"]
-    cmd_parts = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2", "|", "gzip"]
+    cmd_parts = ["docker", "exec", db_container, "pg_dump", "-U", "dhis", "dhis2", "--exclude-table", "'analytics*'", "|", "gzip"]
     cmd = subprocess.list2cmdline(cmd_parts)
     utils.logger.info("Dump SQL for image: {}".format(cmd))
 

--- a/src/d2_docker/commands/run_sql.py
+++ b/src/d2_docker/commands/run_sql.py
@@ -36,8 +36,8 @@ def run(args):
         else:
             if sql_file:
                 utils.logger.info("Run SQL file {} for image {}".format(sql_file, image_name))
-
-            cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *get_pg_dump_command(exclude_table=False, compress=False)]
+            psql_cmd = ["psql", "-U", "dhis", "dhis2"]
+            cmd = ["docker", "exec", ("-i" if sql_file else "-it"), db_container, *psql_cmd]
             stdin = open(sql_file, encoding="utf-8") if sql_file else None
             result = utils.run(cmd, stdin=stdin, raise_on_error=False)
 

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -493,7 +493,6 @@ def export_database(image_name, db_path):
         run_docker_compose(cmd, image_name, stdout=db_file)
 
 
-
 def get_pg_dump_command(exclude_table=True, compress=True):
     cmd = ["pg_dump", "-U", "dhis", "dhis2"]
 

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -487,7 +487,7 @@ def export_database(image_name, db_path):
     mkdir_p(os.path.dirname(db_path))
 
     with open(db_path, "wb") as db_file:
-        pg_dump = "set -o pipefail; pg_dump -U dhis dhis2 | gzip"
+        pg_dump = "set -o pipefail; pg_dump -U dhis dhis2 --exclude-table 'analytics*' | gzip"
         # -T: Disable pseudo-tty allocation. Otherwise the compressed output pipe is corrupted.
         cmd = ["exec", "-T", "db", "bash", "-c", pg_dump]
         run_docker_compose(cmd, image_name, stdout=db_file)

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -487,10 +487,23 @@ def export_database(image_name, db_path):
     mkdir_p(os.path.dirname(db_path))
 
     with open(db_path, "wb") as db_file:
-        pg_dump = "set -o pipefail; pg_dump -U dhis dhis2 --exclude-table 'analytics*' | gzip"
+        pg_dump = "set -o pipefail; " + " ".join(get_pg_dump_command())
         # -T: Disable pseudo-tty allocation. Otherwise the compressed output pipe is corrupted.
         cmd = ["exec", "-T", "db", "bash", "-c", pg_dump]
         run_docker_compose(cmd, image_name, stdout=db_file)
+
+
+
+def get_pg_dump_command(exclude_table=True, compress=True):
+    cmd = ["pg_dump", "-U", "dhis", "dhis2"]
+
+    if exclude_table:
+        cmd += ["--exclude-table", "'analytics*'"]
+
+    if compress:
+        cmd += ["|", "gzip"]
+
+    return cmd
 
 
 def load_images_file(input_file):


### PR DESCRIPTION
I have added the exclusion of analytics tables in the pg_dumps, and it works when using d2-docker copy x y. 
