### PR TITLE
[feature] Increase HTTP header size

### DIFF
--- a/src/d2_docker/config/server.xml
+++ b/src/d2_docker/config/server.xml
@@ -25,6 +25,7 @@
             connectionTimeout="20000"
             URIEncoding="UTF-8"
             relaxedQueryChars='\ { } | [ ]'
+            maxHttpHeaderSize="32768"
         />
 
         <Connector


### PR DESCRIPTION
https://app.clickup.com/t/8698whf2e #8698whf2e

The client detected this on cpr-pro, but it will be useful to add it in d2-docker.

Problem: When a request with email/notification has a long message (worsen by the encoding of non-latin languages) , we hit:  "<!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request".
Solution: Set maxHttpHeaderSize=32k (default: 8k)

```
java.lang.IllegalArgumentException: Request header is too large
        at org.apache.coyote.http11.Http11InputBuffer.fill(Http11InputBuffer.java:790)
        at org.apache.coyote.http11.Http11InputBuffer.parseHeader(Http11InputBuffer.java:971)
        at org.apache.coyote.http11.Http11InputBuffer.parseHeaders(Http11InputBuffer.java:604)
```

Note: The typical error we had with URL length is 414, but here incresing the maxSize allows the long URL, so it's a bit weird. 
