### PR TITLE
[fix] don't fail if the content type JSON is not specified in the request

### DIFF
--- a/src/d2_docker/api/main.py
+++ b/src/d2_docker/api/main.py
@@ -108,7 +108,8 @@ def rm_instance():
 
 def get_request_json(request):
     try:
-        return request.json
+        # Use force so we don't fail even if the content type JSON is not specified in the request
+        return request.get_json(force=True)
     except BadRequest:
         return None
 


### PR DESCRIPTION
Fixes https://app.clickup.com/t/8699cygm6

The transition from Flask v2 to v3 broke the proxy between the API and Harbor. Flask now explicitly validates that the `Content-Type` header is set to `application/json` before attempting to parse the request body as JSON. 

To avoid requiring changes in clients — and since our API consistently uses JSON — we've added the `force=True` flag when parsing request bodies.