### PR TITLE
Fix upgrade command that would stop during docker build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="d2_docker",
-    version="1.16.1",
+    version="1.16.0",
     description="Dockers for DHIS2 instances",
     long_description=open("README.md", encoding="utf-8").read(),
     keywords=["python"],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="d2_docker",
-    version="1.16.0",
+    version="1.16.1",
     description="Dockers for DHIS2 instances",
     long_description=open("README.md", encoding="utf-8").read(),
     keywords=["python"],

--- a/src/d2_docker/commands/create.py
+++ b/src/d2_docker/commands/create.py
@@ -46,26 +46,8 @@ def create_core(args):
 
 def get_core_build_dir(args):
     base_dir = utils.get_docker_directory("core", args)
-    major_version = get_major_version(args.version or args.war)
-    utils.logger.info("DHIS2 major version: {}".format(major_version or "-"))
-
-    if not major_version:
-        raise utils.D2DockerError("Cannot get version from --version or --war")
-    else:
-        if major_version >= 42:
-            return os.path.join(base_dir, "java-17-tomcat-10")
-        elif major_version >= 41:
-            return os.path.join(base_dir, "java-17")
-        else:
-            return os.path.join(base_dir, "java-11")
-
-
-def get_major_version(s):
-    """Return major DHIS2 version. Ex: "2.38.4" -> "38". "40.1.2" -> 40."""
-    match = re.search(r"(\d+\.\d+)", s)
-    if not match: return None
-    parts = [int(s) for s in match.groups()[0].split(".")]
-    return parts[1] if parts[0] == 2 else parts[0]
+    major_version = utils.get_major_version(args.version or args.war)
+    return utils.get_core_java_dir(base_dir, major_version)
 
 
 def create_data(args):

--- a/src/d2_docker/commands/upgrade.py
+++ b/src/d2_docker/commands/upgrade.py
@@ -68,7 +68,7 @@ def upgrade_to_version(
     )
     war_exists = dhis_war_path and os.path.exists(dhis_war_path)
     create_core_kwargs = dict(war=dhis_war_path) if war_exists else dict(version=version)
-    core_docker_dir = utils.get_docker_directory("core")
+    core_docker_dir = utils.get_core_java_dir(utils.get_docker_directory("core"), utils.get_major_version(version))
     utils.create_core(
         docker_dir=core_docker_dir,
         image=core_image,

--- a/src/d2_docker/utils.py
+++ b/src/d2_docker/utils.py
@@ -68,6 +68,28 @@ def copytree(source, dest):
     dir_util.copy_tree(source, dest)
 
 
+def get_core_java_dir(base_dir, major_version):
+    logger.info("DHIS2 major version: {}".format(major_version or "-"))
+
+    if not major_version:
+        raise D2DockerError("Cannot get version from --version or --war")
+    else:
+        if major_version >= 42:
+            return os.path.join(base_dir, "java-17-tomcat-10")
+        elif major_version >= 41:
+            return os.path.join(base_dir, "java-17")
+        else:
+            return os.path.join(base_dir, "java-11")
+        
+
+def get_major_version(s):
+    """Return major DHIS2 version. Ex: "2.38.4" -> "38". "40.1.2" -> 40."""
+    match = re.search(r"(\d+\.\d+)", s)
+    if not match: return None
+    parts = [int(s) for s in match.groups()[0].split(".")]
+    return parts[1] if parts[0] == 2 else parts[0]
+
+
 def run(
     command_parts,
     raise_on_error=True,
@@ -606,6 +628,9 @@ def wait_for_server(port):
     url = "http://localhost:{}".format(port)
 
     while True:
+        # This functions is called right after a "docker up", which takes a little to be able to start the nginx (and way longer for the tomcat to be ready),
+        # so to avoid calling before nginx can accept connections (and raising an exception) just move the sleep to be the first step
+        time.sleep(5)
         try:
             logger.debug("wait_for_server:url={}".format(url))
             urllib.request.urlopen(url)  # nosec
@@ -619,7 +644,6 @@ def wait_for_server(port):
         except urllib.request.URLError as exc:
             logger.debug("wait_for_server:url-error: {}".format(exc.reason))
 
-        time.sleep(5)
 
 
 def create_core(


### PR DESCRIPTION
Fix `upgrade` argument, since it didn't perform the major_version check to choose between the different tomcat/java versions and tried to use `docker build` with 3 different Dockerfile in 3 subfolders instead of the specific one for the version it is trying to upgrade to.

Moved the sleep in wait_for_server to let docker start nginx before trying to connect to it (raising an exception). Even in the best case scenario in which nginx would start before reaching this code, tomcat would likely take a little extra to be ready, so the sleep will take place at least once (usually several times, since a migration would include some SQL to be run before tomcat would be in a ready state and until then a 502 error would be generated each time it is tested).

Moved common parts from `create.py` to `utils.py`