### PR TITLE
[FIX] -k option should keep apps, dataValues, documents, etc. upon restart

### DIFF
--- a/src/d2_docker/commands/rm.py
+++ b/src/d2_docker/commands/rm.py
@@ -15,7 +15,7 @@ def run(args):
 def remove_image(image):
     utils.logger.info("Delete image/containers: {}".format(image))
     utils.run_docker_compose(["stop"], image)
-    result = utils.run_docker_compose(["ps", "-q"], data_image=image, capture_output=True)
+    result = utils.run_docker_compose(["ps", "-aq"], data_image=image, capture_output=True)
     container_ids = result.stdout.decode("utf-8").splitlines()
     utils.logger.debug("Container IDs: {}".format(container_ids))
     if container_ids:

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -166,7 +166,7 @@ run() {
     if is_init_done; then
         debug "Container: already configured. Skip DB load and keeping other changes"
     else
-	debug "Container: clean. Copying tomcat files and dhis folders"
+        debug "Container: clean. Copying tomcat files and dhis folders"
         copy_apps
         copy_documents
         copy_datavalues

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -162,14 +162,14 @@ init_done() {
 run() {
     local host=$1 psql_port=$2
 
-    setup_tomcat
-    copy_apps
-    copy_documents
-    copy_datavalues
-
     if is_init_done; then
-        debug "Container: already configured. Skip DB load"
+        debug "Container: already configured. Skip DB load and keeping other changes"
     else
+	debug "Container: clean. Copying tomcat files and dhis folders"
+        setup_tomcat
+        copy_apps
+        copy_documents
+        copy_datavalues
         debug "Container: clean. Load DB"
         wait_for_postgres
         run_sql_files

--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -162,11 +162,11 @@ init_done() {
 run() {
     local host=$1 psql_port=$2
 
+    setup_tomcat
     if is_init_done; then
         debug "Container: already configured. Skip DB load and keeping other changes"
     else
 	debug "Container: clean. Copying tomcat files and dhis folders"
-        setup_tomcat
         copy_apps
         copy_documents
         copy_datavalues


### PR DESCRIPTION
Moved 4 functions inside a condition to avoid resetting container folders to the original content (it didn't erase contents, but overwrote any change on those folders with the files' previous version)