### PR TITLE
[DO NOT MERGE] Quick fix for EFH.

### DIFF
--- a/src/d2_docker/docker-compose.yml
+++ b/src/d2_docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         entrypoint: bash /config/dhis2-core-entrypoint.sh
         command: bash /config/dhis2-core-start.sh
         stop_grace_period: 10s
-        restart: "no"
+        restart: unless-stopped
         depends_on:
             - "db"
             - "data"


### PR DESCRIPTION
Quick fix for EFH.
Restored the restart:unless-stopped to the core container.
This SHOULD NOT be merged back into development until the functionality of d2-cloner is evaluated, but it will probably require more work on both d2-docker and d2-cloner.
