### PR TITLE
Change runner type from self-hosted to general-runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: self-hosted
+    runs-on: general-runner
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
Pull Request: Update GitHub Actions runner tags
Summary
This PR updates the workflow configuration to change the runner label from self-hosted to general-runner.

Note: Some minor whitespace changes in the workflow file were auto-formatted by the GitHub web editor.

Context
Currently, we use the self-hosted tag, which is a default label shared across all custom runners not managed by GitHub. To improve our infrastructure management, we have deployed new virtual machines and need a way to differentiate between them.

Changes
Updated runs-on: self-hosted to runs-on: general-runner in all workflow files.

Why this is necessary
Using general-runner allows us to:

Isolate workloads: Ensure jobs run on the specific VM intended for these tasks.

Granular Control: Avoid resource conflicts with other custom runners using the generic self-hosted tag.

Scalability: Better tracking of runner usage and performance.


