### PR TITLE
extract error logic and improve error code workflow

### DIFF
--- a/src/d2_docker/config/dhis2-core-start.sh
+++ b/src/d2_docker/config/dhis2-core-start.sh
@@ -44,6 +44,15 @@ debug() {
     echo "[dhis2-core-start] $*" >&2
 }
 
+setup_error_page() {
+    debug "Setting up error page (application removed)"
+    rm -rvf "$approot"
+    mkdir -p -m 750 "$approot"
+    chown tomcat:tomcat "$approot"
+    echo '<!DOCTYPE html><title>Error</title>
+    Error during preparation of the service' > "$approot/index.html"
+}
+
 run_sql_files() {
     base_db_path=$(test "${LOAD_FROM_DATA}" = "yes" && echo "$root_db_path" || echo "$post_db_path")
     debug "Files in data path"
@@ -65,22 +74,24 @@ run_sql_files() {
         zcat "$path" | $psql_cmd || true
     done
 
-    find "$base_db_path" -type f \( -name '*.sql' \) |
-        sort | while read -r path; do
+    local sql_error=0
+    while read -r path; do
         echo "Load SQL: $path"
         exit_code=0
         run_psql_cmd "$path" || exit_code=$?
         if [ "$exit_code" -gt 0 ]; then
             echo "Exit code: $exit_code"
-            touch "$flag_sql_error"
-            rm -rvf $approot
-            mkdir -p -m 750 $approot
-            chown tomcat:tomcat $approot
-            echo '<!DOCTYPE html><title>Error</title>
-            Error during preparation of the service' > $approot/index.html
-            exit "$exit_code"
+            sql_error=1
+            break
         fi
-    done
+    done < <(find "$base_db_path" -type f \( -name '*.sql' \) | sort)
+
+    if [ "$sql_error" -gt 0 ]; then
+        touch "$flag_sql_error"
+        setup_error_page
+        return 1
+    fi
+    return 0
 }
 
 run_psql_cmd() {
@@ -201,6 +212,18 @@ run() {
     local host=$1 psql_port=$2
 
     setup_tomcat
+
+    # If a previous SQL error was flagged (persisted in named volume), keep showing error page
+    if [ -f "$flag_sql_error" ]; then
+        debug "SQL error flag detected from a previous run. Container will start with error page only."
+        setup_error_page
+        start_tomcat &
+        LAST_PID=$!
+        debug "Container is running with error page. Fix the SQL issue and remove the flag ($flag_sql_error) to recover."
+        wait $LAST_PID || true
+        return
+    fi
+
     if is_init_done; then
         debug "Container: already configured. Skip DB load and keeping other changes"
     else
@@ -210,7 +233,14 @@ run() {
         copy_datavalues
         debug "Container: clean. Load DB"
         wait_for_postgres
-        run_sql_files
+        if ! run_sql_files; then
+            debug "SQL error detected. Container will start with error page only."
+            start_tomcat &
+            LAST_PID=$!
+            debug "Fix the SQL issue and remove the flag ($flag_sql_error) to recover."
+            wait $LAST_PID || true
+            return
+        fi
         run_pre_scripts || true
         init_done
     fi


### PR DESCRIPTION
Summary of the 3 Problems Causing the Infinite Loop and the Changes Made
Root Cause
exit in a pipeline (subshell): Using find ... | while ... exit killed the subshell. Because set -e and pipefail were active, the error propagated, killing the entire script and causing the container to exit with code 3.

restart: unless-stopped: Docker automatically restarted the container upon detecting a non-zero exit code.

Flag check was missing: While flag_sql_error was created in the home volume, nothing was reading it during startup. Consequently, every restart repeated the entire failing process.

Changes in dhis2-core-start.sh
New function setup_error_page(): This logic was extracted into a standalone function to reuse the process of deleting the WAR file and deploying the HTML error page.

run_sql_files no longer kills the container:

The find | while pipeline was changed to while ... done < <(find ...) (process substitution). This ensures the loop runs within the main shell context.

Instead of calling exit "$exit_code", it now executes touch flag, calls setup_error_page, and returns 1.

run() checks the flag on startup: If flag_sql_error exists (persisted in the home volume), it mounts the error page and starts Tomcat without attempting to run SQL again. The container remains "healthy" (running) but inaccessible, showing only the error HTML.

run() handles SQL errors: The logic if ! run_sql_files now captures the failure and starts Tomcat with the error page, keeping the container alive.

Resulting Workflow
SQL Error: The container stays alive, displaying the "Error during preparation of the service" page. No more infinite reboots.

Server Restart: The flag persists in the volume, so the container continues to show the error page without attempting to re-execute the faulty SQL.

Recovery: Fix the SQL, delete the /DHIS2_home/flag-sql-error file (via d2-docker shell or similar), and restart.