### PR TITLE
chore: bump version to 1.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="d2_docker",
-    version="1.16.0",
+    version="1.18.0",
     description="Dockers for DHIS2 instances",
     long_description=open("README.md", encoding="utf-8").read(),
     keywords=["python"],


### PR DESCRIPTION
Bumps `setup.py` version from `1.16.0` to `1.18.0` so the packaged version matches the upcoming 1.18.0 release.

This was missed in the "Release 1.18.0" PR (#163), where `setup.py` was left at `1.16.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)